### PR TITLE
Improve logging for development

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -11,17 +11,30 @@ function createChatStore() {
 
   function connect(url: string) {
     if (socket) return;
+    if (import.meta.env.DEV) console.log('Connecting to WebSocket', url);
     socket = new WebSocket(url);
+    socket.addEventListener('open', () => {
+      if (import.meta.env.DEV) console.log('WebSocket connection opened');
+    });
     socket.addEventListener('message', (ev) => {
+      if (import.meta.env.DEV) console.log('Received:', ev.data);
       try {
         const msg: Message = JSON.parse(ev.data);
         update((m) => [...m, msg]);
       } catch (_) {}
     });
+    socket.addEventListener('close', () => {
+      if (import.meta.env.DEV) console.log('WebSocket connection closed');
+      socket = null;
+    });
+    socket.addEventListener('error', (e) => {
+      if (import.meta.env.DEV) console.error('WebSocket error', e);
+    });
   }
 
   function send(user: string, text: string) {
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (import.meta.env.DEV) console.log('Sending:', { user, text });
       socket.send(JSON.stringify({ user, text }));
     }
   }

--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "hyper",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -1104,7 +1105,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -8,5 +8,6 @@ axum = { version = "0.7", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 hyper = "1"
 tracing-subscriber = "0.3"
+tracing = "0.1"
 futures = "0.3"
 tokio-postgres = "0.7"


### PR DESCRIPTION
## Summary
- add dev console logs for WebSocket events on the client
- log server startup, connections and messages using tracing
- pull in the `tracing` crate for the server

## Testing
- `cargo check`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6869755b44ac83278c843cefc87f7849