### PR TITLE
[Murmer] Add AGENTS guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Contributor Guide
+
+This repository hosts **Murmer**, a minimal voice and text chat prototype.
+It is split into a Tauri/SvelteKit client and a Rust server.
+
+## Repository Structure
+- `murmer_client/` – desktop client built with Tauri and SvelteKit.
+- `murmer_server/` – Rust WebSocket server that persists chat messages to Postgres.
+- `docker-compose.yml` – runs the server together with Postgres.
+
+Each subfolder contains its own `AGENTS.md` with more details.
+
+## Getting Started
+1. Install [Rust](https://www.rust-lang.org/tools/install) and [Node.js](https://nodejs.org) v18 or newer.
+2. See `README.md` for quick commands to run the client and server.
+
+## Validation
+- There is currently no automated test suite.
+- Run `npm run check` inside `murmer_client` to perform Svelte/TypeScript checks.
+- Format Rust code with `cargo fmt` before committing.
+
+## Docker
+Use `docker compose up --build` to start the server and a Postgres database defined in `docker-compose.yml`.

--- a/murmer_client/AGENTS.md
+++ b/murmer_client/AGENTS.md
@@ -1,0 +1,12 @@
+# murmer_client Guide
+
+This directory contains the Tauri/SvelteKit desktop client.
+
+## Setup
+1. Run `npm install` to install dependencies.
+2. Launch the app with `npm run tauri dev`.
+
+The Tauri configuration in `src-tauri/tauri.conf.json` runs `npm run dev` during development.
+
+## Validation
+Run `npm run check` to perform Svelte and TypeScript checks. There are no automated tests yet.

--- a/murmer_server/AGENTS.md
+++ b/murmer_server/AGENTS.md
@@ -1,0 +1,18 @@
+# murmer_server Guide
+
+This folder hosts the Rust WebSocket server built with Axum.
+
+## Running
+1. Ensure Postgres is available and set `DATABASE_URL` accordingly.
+2. Start the server with `cargo run`.
+
+You can also run the server together with Postgres via Docker Compose from the repository root:
+
+```bash
+docker compose up --build
+```
+
+The server listens on `ws://localhost:3001/ws`.
+
+## Validation
+There are no automated tests. Format code with `cargo fmt` before committing.


### PR DESCRIPTION
## Summary
- document repo structure and basic workflow in `AGENTS.md`
- add client and server guides so future contributors know how to run them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869803f75a88327b3d5cde9f94477bb