### PR TITLE
Add persistent server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ This launches the desktop app.
 cd murmer_server
 cargo run
 ```
-The server exposes a WebSocket endpoint at `ws://localhost:3001/ws` used by the client for chat.
+The server exposes a WebSocket endpoint at `ws://localhost:3001/ws`.
+The client can store multiple server URLs and connect to any of them via the
+"Servers" screen. Added servers are persisted locally so favorites remain after
+restart.
 
 ### Using Docker with Postgres
 To run the server together with a Postgres database, use Docker Compose:

--- a/murmer_client/src/lib/stores/servers.ts
+++ b/murmer_client/src/lib/stores/servers.ts
@@ -1,0 +1,57 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'murmer_servers';
+const SELECTED_KEY = 'murmer_selected_server';
+
+function loadServers(): string[] {
+  if (!browser) return [];
+  const data = localStorage.getItem(STORAGE_KEY);
+  try {
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persist(list: string[]) {
+  if (browser) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  }
+}
+
+const { subscribe, update } = writable<string[]>(loadServers());
+
+export const servers = {
+  subscribe,
+  add(server: string) {
+    update((list) => {
+      if (!list.includes(server)) {
+        const newList = [...list, server];
+        persist(newList);
+        return newList;
+      }
+      return list;
+    });
+  },
+  remove(server: string) {
+    update((list) => {
+      const newList = list.filter((s) => s !== server);
+      persist(newList);
+      return newList;
+    });
+  }
+};
+
+const initialSelected = browser ? localStorage.getItem(SELECTED_KEY) : null;
+export const selectedServer = writable<string | null>(initialSelected);
+
+selectedServer.subscribe((value) => {
+  if (browser) {
+    if (value) {
+      localStorage.setItem(SELECTED_KEY, value);
+    } else {
+      localStorage.removeItem(SELECTED_KEY);
+    }
+  }
+});

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -3,6 +3,8 @@
   import { chat } from '$lib/stores/chat';
   import { session } from '$lib/stores/session';
   import { voice } from '$lib/stores/voice';
+  import { selectedServer } from '$lib/stores/servers';
+  import { get } from 'svelte/store';
   let message = '';
   let inVoice = false;
 
@@ -16,7 +18,8 @@
   }
 
   onMount(() => {
-    chat.connect('ws://localhost:3001/ws');
+    const url = get(selectedServer) ?? 'ws://localhost:3001/ws';
+    chat.connect(url);
   });
 
   function send() {

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -1,17 +1,45 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  let servers = ['Example Server'];
-  function join() {
+  import { servers, selectedServer } from '$lib/stores/servers';
+  import { get } from 'svelte/store';
+
+  let newServer = '';
+
+  function normalize(input: string): string {
+    let url = input.trim();
+    if (!/^wss?:\/\//.test(url)) {
+      if (/^https?:\/\//.test(url)) {
+        url = url.replace(/^http/, 'ws');
+      } else {
+        url = `ws://${url.replace(/\/$/, '')}/ws`;
+      }
+    }
+    return url;
+  }
+
+  function add() {
+    if (newServer.trim()) {
+      servers.add(normalize(newServer));
+      newServer = '';
+    }
+  }
+
+  function join(server: string) {
+    selectedServer.set(server);
     goto('/chat');
   }
 </script>
 
 <div class="p-4">
   <h1 class="text-xl font-bold mb-4">Servers</h1>
+  <div class="mb-4 flex space-x-2">
+    <input class="border p-2 rounded flex-1" bind:value={newServer} placeholder="host:port or ws://url" />
+    <button class="bg-blue-500 text-white px-4 py-2 rounded" on:click={add}>Add</button>
+  </div>
   <ul>
-    {#each servers as server}
+    {#each $servers as server}
       <li class="mb-2">
-        <button class="bg-gray-200 p-2 rounded w-full text-left" on:click={join}>{server}</button>
+        <button class="bg-gray-200 p-2 rounded w-full text-left" on:click={() => join(server)}>{server}</button>
       </li>
     {/each}
   </ul>


### PR DESCRIPTION
## Summary
- implement a `servers` store that persists server URLs and selected server to `localStorage`
- allow adding servers and selecting from them in the Servers page
- connect to the selected server when opening the Chat page
- update README with instructions about the new persistent server list

## Testing
- `npm run check` inside `murmer_client`
- `cargo fmt` inside `murmer_server`

------
https://chatgpt.com/codex/tasks/task_e_686a31418804832793942665e25a043b