### PR TITLE
Add online users sidebar

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -20,12 +20,13 @@ function createChatStore() {
     delete handlers[type];
   }
 
-  function connect(url: string) {
+  function connect(url: string, onOpen?: () => void) {
     if (socket) return;
     if (import.meta.env.DEV) console.log('Connecting to WebSocket', url);
     socket = new WebSocket(url);
     socket.addEventListener('open', () => {
       if (import.meta.env.DEV) console.log('WebSocket connection opened');
+      if (onOpen) onOpen();
     });
     socket.addEventListener('message', (ev) => {
       if (import.meta.env.DEV) console.log('Received:', ev.data);

--- a/murmer_client/src/lib/stores/online.ts
+++ b/murmer_client/src/lib/stores/online.ts
@@ -1,0 +1,15 @@
+import { writable } from 'svelte/store';
+import { chat } from './chat';
+import type { Message } from './chat';
+
+function createOnlineStore() {
+  const { subscribe, set } = writable<string[]>([]);
+  chat.on('online-users', (msg: Message) => {
+    if (Array.isArray(msg.users)) {
+      set(msg.users as string[]);
+    }
+  });
+  return { subscribe };
+}
+
+export const onlineUsers = createOnlineStore();

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -4,6 +4,7 @@
   import { session } from '$lib/stores/session';
   import { voice } from '$lib/stores/voice';
   import { selectedServer } from '$lib/stores/servers';
+  import { onlineUsers } from '$lib/stores/online';
   import { get } from 'svelte/store';
   let message = '';
   let inVoice = false;
@@ -19,7 +20,10 @@
 
   onMount(() => {
     const url = get(selectedServer) ?? 'ws://localhost:3001/ws';
-    chat.connect(url);
+    chat.connect(url, () => {
+      const u = get(session).user;
+      if (u) chat.sendRaw({ type: 'presence', user: u });
+    });
   });
 
   function send() {
@@ -40,28 +44,38 @@
   }
 </script>
 
-  <div class="flex flex-col h-screen p-4">
-  <h1 class="text-xl font-bold mb-4">Text Channel</h1>
-  <div class="flex-1 overflow-y-auto mb-4 space-y-2">
-    {#each $chat as msg}
-      <div><b>{msg.user}:</b> {msg.text}</div>
-    {/each}
-  </div>
-  <div class="flex space-x-2">
-    <input class="flex-1 border p-2 rounded" bind:value={message} placeholder="Message" />
-    <button class="bg-blue-500 text-white px-4 py-2 rounded" on:click={send}>Send</button>
-  </div>
-  {#if inVoice}
-    <button class="mt-4 bg-red-500 text-white px-4 py-2 rounded self-start" on:click={leaveVoice}>
-      Leave Voice
-    </button>
-  {:else}
-    <button class="mt-4 bg-green-500 text-white px-4 py-2 rounded self-start" on:click={joinVoice}>
-      Join Voice
-    </button>
-  {/if}
+  <div class="flex h-screen">
+    <div class="flex flex-col flex-1 p-4">
+      <h1 class="text-xl font-bold mb-4">Text Channel</h1>
+      <div class="flex-1 overflow-y-auto mb-4 space-y-2">
+        {#each $chat as msg}
+          <div><b>{msg.user}:</b> {msg.text}</div>
+        {/each}
+      </div>
+      <div class="flex space-x-2">
+        <input class="flex-1 border p-2 rounded" bind:value={message} placeholder="Message" />
+        <button class="bg-blue-500 text-white px-4 py-2 rounded" on:click={send}>Send</button>
+      </div>
+      {#if inVoice}
+        <button class="mt-4 bg-red-500 text-white px-4 py-2 rounded self-start" on:click={leaveVoice}>
+          Leave Voice
+        </button>
+      {:else}
+        <button class="mt-4 bg-green-500 text-white px-4 py-2 rounded self-start" on:click={joinVoice}>
+          Join Voice
+        </button>
+      {/if}
 
-  {#each $voice as peer (peer.id)}
-    <audio autoplay use:stream={peer.stream}></audio>
-  {/each}
-</div>
+      {#each $voice as peer (peer.id)}
+        <audio autoplay use:stream={peer.stream}></audio>
+      {/each}
+    </div>
+    <div class="w-48 p-4 border-l overflow-y-auto">
+      <h2 class="text-lg font-bold mb-2">Online</h2>
+      <ul class="space-y-1">
+        {#each $onlineUsers as user}
+          <li>{user}</li>
+        {/each}
+      </ul>
+    </div>
+  </div>


### PR DESCRIPTION
## Summary
- server: track connected users and broadcast online list
- client: expose `onlineUsers` store
- chat page: show who is online on the right side

## Testing
- `cargo check` in `murmer_server`
- `npm run check` in `murmer_client`

------
https://chatgpt.com/codex/tasks/task_e_686a375a24208327b761e9e5d33ecc24