### PR TITLE
Add server naming

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ Use the checkboxes to track progress.
 ### 🛠️ Other Features
 
 - [ ] Remember user nicknames (locally or server-side)
-- [ ] Assign a name to the server
+- [x] Assign a name to the server
 - [ ] Implement launcher and update checker
 - [ ] Add a logo for the app
 

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  import { servers, selectedServer } from '$lib/stores/servers';
+  import { servers, selectedServer, type ServerEntry } from '$lib/stores/servers';
   import { get } from 'svelte/store';
 
   let newServer = '';
+  let newName = '';
 
   function normalize(input: string): string {
     let url = input.trim();
@@ -19,13 +20,14 @@
 
   function add() {
     if (newServer.trim()) {
-      servers.add(normalize(newServer));
+      servers.add({ url: normalize(newServer), name: newName.trim() || newServer });
       newServer = '';
+      newName = '';
     }
   }
 
-  function join(server: string) {
-    selectedServer.set(server);
+  function join(server: ServerEntry) {
+    selectedServer.set(server.url);
     goto('/chat');
   }
 </script>
@@ -33,13 +35,16 @@
 <div class="p-4">
   <h1 class="text-xl font-bold mb-4">Servers</h1>
   <div class="mb-4 flex space-x-2">
+    <input class="border p-2 rounded flex-1" bind:value={newName} placeholder="Server name" />
     <input class="border p-2 rounded flex-1" bind:value={newServer} placeholder="host:port or ws://url" />
     <button class="bg-blue-500 text-white px-4 py-2 rounded" on:click={add}>Add</button>
   </div>
   <ul>
     {#each $servers as server}
       <li class="mb-2">
-        <button class="bg-gray-200 p-2 rounded w-full text-left" on:click={() => join(server)}>{server}</button>
+        <button class="bg-gray-200 p-2 rounded w-full text-left" on:click={() => join(server)} title={server.url}>
+          {server.name}
+        </button>
       </li>
     {/each}
   </ul>


### PR DESCRIPTION
## Summary
- allow naming servers when adding to the server list
- store names in local storage and display them
- mark TODO item as done

## Testing
- `npm run check`
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_686a5884074c8327a6ca15f819e1e0a3