### PR TITLE
Fix missing column on server startup

### DIFF
--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -99,7 +99,14 @@ async fn main() {
     });
     db_client
         .batch_execute(
-            "CREATE TABLE IF NOT EXISTS messages (id SERIAL PRIMARY KEY, channel TEXT NOT NULL, content TEXT NOT NULL)",
+            r#"CREATE TABLE IF NOT EXISTS messages (
+    id SERIAL PRIMARY KEY,
+    channel TEXT NOT NULL,
+    content TEXT NOT NULL
+);
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS channel TEXT NOT NULL DEFAULT 'general';
+"#,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- ensure server adds `channel` column when messages table already exists

## Testing
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_686a5af7b2348327ba831559bfc24002