### PR TITLE
Implement username persistence and logout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ Use the checkboxes to track progress.
 
 ### 🛠️ Other Features
 
-- [ ] Remember user nicknames (locally or server-side)
+- [x] Remember user nicknames (locally or server-side)
 - [ ] Implement launcher and update checker
 - [ ] Add a logo for the app
 

--- a/murmer_client/src/lib/stores/session.ts
+++ b/murmer_client/src/lib/stores/session.ts
@@ -1,4 +1,18 @@
 import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'murmer_user';
+
+const initial = browser ? localStorage.getItem(STORAGE_KEY) : null;
 
 /** Simple session store holding the logged in user */
-export const session = writable<{ user: string | null }>({ user: null });
+export const session = writable<{ user: string | null }>({ user: initial });
+
+session.subscribe((value) => {
+  if (!browser) return;
+  if (value.user) {
+    localStorage.setItem(STORAGE_KEY, value.user);
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+});

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -6,6 +6,7 @@
   import { selectedServer } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
   import { get } from 'svelte/store';
+  import { goto } from '$app/navigation';
   let message = '';
   let inVoice = false;
   const channels = ['general', 'random'];
@@ -21,6 +22,10 @@
   }
 
   onMount(() => {
+    if (!get(session).user) {
+      goto('/login');
+      return;
+    }
     const url = get(selectedServer) ?? 'ws://localhost:3001/ws';
     chat.connect(url, () => {
       const u = get(session).user;
@@ -54,6 +59,11 @@
     inVoice = false;
   }
 
+  function logout() {
+    session.set({ user: null });
+    goto('/login');
+  }
+
   let messagesContainer: HTMLDivElement;
   let lastLength = 0;
 
@@ -67,7 +77,14 @@
 
   <div class="flex h-screen">
     <div class="flex flex-col flex-1 p-4">
-      <h1 class="text-xl font-bold mb-4">Text Channel</h1>
+      <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-bold">Text Channel</h1>
+        <div class="space-x-2 flex items-center">
+          <span class="text-sm">{$session.user}</span>
+          <button class="bg-gray-300 px-2 py-1 rounded" on:click={logout}
+            >Logout</button>
+        </div>
+      </div>
       <div class="mb-4 space-x-2">
         {#each channels as ch}
           <button

--- a/murmer_client/src/routes/login/+page.svelte
+++ b/murmer_client/src/routes/login/+page.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
   import { session } from '$lib/stores/session';
   import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   let username = '';
+
+  onMount(() => {
+    const existing = get(session).user;
+    if (existing) {
+      goto('/servers');
+    }
+  });
+
   function login() {
     session.set({ user: username });
     goto('/servers');

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { servers, selectedServer, type ServerEntry } from '$lib/stores/servers';
+  import { session } from '$lib/stores/session';
+  import { onMount } from 'svelte';
   import { get } from 'svelte/store';
+
+  onMount(() => {
+    if (!get(session).user) goto('/login');
+  });
 
   let newServer = '';
   let newName = '';
@@ -34,10 +40,21 @@
   function removeServer(url: string) {
     servers.remove(url);
   }
+
+  function logout() {
+    session.set({ user: null });
+    goto('/login');
+  }
 </script>
 
 <div class="p-4">
-  <h1 class="text-xl font-bold mb-4">Servers</h1>
+  <div class="flex items-center justify-between mb-4">
+    <h1 class="text-xl font-bold">Servers</h1>
+    <div class="space-x-2 flex items-center">
+      <span class="text-sm">{$session.user}</span>
+      <button class="bg-gray-300 px-2 py-1 rounded" on:click={logout}>Logout</button>
+    </div>
+  </div>
   <div class="mb-4 flex space-x-2">
     <input class="border p-2 rounded flex-1" bind:value={newName} placeholder="Server name" />
     <input class="border p-2 rounded flex-1" bind:value={newServer} placeholder="host:port or ws://url" />


### PR DESCRIPTION
## Summary
- persist username to local storage with a `session` store
- auto-redirect to servers page if a session already exists
- add logout buttons on servers and chat pages
- guard protected pages when not logged in
- mark TODO for remembering nicknames

## Testing
- `npm run check`
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_686a6a7532688327901a51274620ff84