### PR TITLE
Add voice presence tracking

### DIFF
--- a/murmer_client/src/lib/stores/voiceUsers.ts
+++ b/murmer_client/src/lib/stores/voiceUsers.ts
@@ -1,0 +1,15 @@
+import { writable } from 'svelte/store';
+import { chat } from './chat';
+import type { Message } from './chat';
+
+function createVoiceUserStore() {
+  const { subscribe, set } = writable<string[]>([]);
+  chat.on('voice-users', (msg: Message) => {
+    if (Array.isArray(msg.users)) {
+      set(msg.users as string[]);
+    }
+  });
+  return { subscribe };
+}
+
+export const voiceUsers = createVoiceUserStore();

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -5,6 +5,7 @@
   import { voice } from '$lib/stores/voice';
   import { selectedServer } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
+  import { voiceUsers } from '$lib/stores/voiceUsers';
   import { get } from 'svelte/store';
   let message = '';
   let inVoice = false;
@@ -113,8 +114,14 @@
     </div>
     <div class="w-48 p-4 border-l overflow-y-auto">
       <h2 class="text-lg font-bold mb-2">Online</h2>
-      <ul class="space-y-1">
+      <ul class="space-y-1 mb-4">
         {#each $onlineUsers as user}
+          <li>{user}</li>
+        {/each}
+      </ul>
+      <h2 class="text-lg font-bold mb-2">Voice</h2>
+      <ul class="space-y-1">
+        {#each $voiceUsers as user}
           <li>{user}</li>
         {/each}
       </ul>


### PR DESCRIPTION
## Summary
- broadcast voice channel membership from the server
- track voice users in a new `voiceUsers` store
- list active voice users in the chat sidebar

## Testing
- `npm run check` in `murmer_client`
- `cargo fmt --manifest-path murmer_server/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686a6ab8afb483279871eae5607269f0