### PR TITLE
Add connection strength indicator

### DIFF
--- a/murmer_client/src/lib/components/ConnectionBars.svelte
+++ b/murmer_client/src/lib/components/ConnectionBars.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  export let strength: number = 0;
+  const bars = [1, 2, 3, 4, 5];
+</script>
+
+<div class="flex items-end ml-1">
+  {#each bars as n}
+    <div
+      class="w-1 mx-px bg-gray-400"
+      class:bg-green-500={strength >= n}
+      style="height: {n * 0.25}rem"
+    ></div>
+  {/each}
+</div>

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -2,12 +2,17 @@
   import { onMount, afterUpdate } from 'svelte';
   import { chat } from '$lib/stores/chat';
   import { session } from '$lib/stores/session';
-  import { voice } from '$lib/stores/voice';
+  import { voice, voiceStats } from '$lib/stores/voice';
   import { selectedServer } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
   import { voiceUsers } from '$lib/stores/voiceUsers';
   import { get } from 'svelte/store';
   import { goto } from '$app/navigation';
+  import ConnectionBars from '$lib/components/ConnectionBars.svelte';
+  function strength(user: string): number {
+    const stats = get(voiceStats)[user];
+    return stats ? stats.strength : 0;
+  }
   let message = '';
   let inVoice = false;
   const channels = ['general', 'random'];
@@ -139,7 +144,12 @@
       <h2 class="text-lg font-bold mb-2">Voice</h2>
       <ul class="space-y-1">
         {#each $voiceUsers as user}
-          <li>{user}</li>
+          <li class="flex items-center">
+            <span>{user}</span>
+            {#if user !== $session.user}
+              <ConnectionBars strength={strength(user)} />
+            {/if}
+          </li>
         {/each}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- compute peer connection stats in the voice store
- export `voiceStats` derived store for easy access
- add `ConnectionBars` component
- display strength bars next to users in the voice list

## Testing
- `npm run check` within `murmer_client`
- `cargo fmt` within `murmer_server`


------
https://chatgpt.com/codex/tasks/task_e_686a6d53fb2c8327888901e1ed1524c5