### PR TITLE
Add system tray with minimize behavior

### DIFF
--- a/murmer_client/src-tauri/src/lib.rs
+++ b/murmer_client/src-tauri/src/lib.rs
@@ -6,8 +6,53 @@ fn greet(name: &str) -> String {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    use tauri::{CustomMenuItem, SystemTray, SystemTrayEvent, SystemTrayMenu, Manager};
+
+    let open = CustomMenuItem::new("open", "\u00d6ffnen");
+    let quit = CustomMenuItem::new("quit", "Schlie\u00dfen");
+    let tray_menu = SystemTrayMenu::new().add_item(open).add_item(quit);
+    let tray = SystemTray::new().with_menu(tray_menu);
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .system_tray(tray)
+        .on_system_tray_event(|app, event| match event {
+            SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
+                "open" => {
+                    if let Some(window) = app.get_window("main") {
+                        window.show().ok();
+                        window.set_focus().ok();
+                    }
+                }
+                "quit" => app.exit(0),
+                _ => {}
+            },
+            SystemTrayEvent::DoubleClick { .. } => {
+                if let Some(window) = app.get_window("main") {
+                    window.show().ok();
+                    window.set_focus().ok();
+                }
+            }
+            _ => {}
+        })
+        .on_window_event(|event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event.event() {
+                let window = event.window().clone();
+                api.prevent_close();
+                tauri::api::dialog::ask(
+                    Some(&window),
+                    "Beenden?",
+                    "M\u00f6chtest du den Client minimieren oder schlie\u00dfen?",
+                    move |minimize| {
+                        if minimize {
+                            window.hide().ok();
+                        } else {
+                            std::process::exit(0);
+                        }
+                    },
+                );
+            }
+        })
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -9,18 +9,21 @@
 		"beforeBuildCommand": "npm run build",
 		"frontendDist": "../build"
 	},
-	"app": {
-		"windows": [
-			{
-				"title": "murmer_client",
-				"width": 800,
-				"height": 600
-			}
-		],
-		"security": {
-			"csp": null
-		}
-	},
+        "app": {
+                "windows": [
+                        {
+                                "title": "murmer_client",
+                                "width": 800,
+                                "height": 600
+                        }
+                ],
+                "trayIcon": {
+                        "iconPath": "icons/icon.png"
+                },
+                "security": {
+                        "csp": null
+                }
+        },
 	"bundle": {
 		"active": true,
 		"targets": "all",


### PR DESCRIPTION
## Summary
- show a tray icon for murmer_client
- confirm on window close whether to minimize or exit
- allow opening and quitting from tray menu and double click to restore

## Testing
- `npm run check`
- `cargo fmt` *(fails: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a78422cd883299993cb0cd2a030fa