### PR TITLE
Fix Svelte warning

### DIFF
--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import '../app.css';
-  export let data;
 </script>
 
 <slot />


### PR DESCRIPTION
## Summary
- remove unused `data` export from the root layout component

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686a86b2993883279a48647208b10930