### PR TITLE
Add image upload support with MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,31 @@ This launches the desktop app.
 ### Prerequisite
 Docker is required to host a server.
 
-Use Docker Compose to run the server together with a Postgres database:
+Use Docker Compose to run the server together with Postgres and MinIO:
 ```bash
 docker compose up --build
 ```
 The server exposes a WebSocket endpoint at `ws://localhost:3001/ws`. The client can store multiple server URLs and connect to any of them via the "Servers" screen. Added servers are persisted locally so favorites remain after restart.
 The `DATABASE_URL` used by the server is defined in `docker-compose.yml`.
 
+### Image Uploads
+
+The server stores uploaded images in a MinIO bucket. Configure the following environment variables when running the server:
+
+```
+MINIO_ENDPOINT=<http://localhost:9000>
+MINIO_BUCKET=<bucket-name>
+MINIO_PUBLIC_URL=<public-base-url>
+AWS_ACCESS_KEY_ID=<access-key>
+AWS_SECRET_ACCESS_KEY=<secret-key>
+```
+
+`MINIO_PUBLIC_URL` should be the base URL clients use to access objects. The bucket is created separately.
+
+`docker-compose.yml` starts a MinIO instance with the default `minioadmin` credentials and uses a bucket named `murmer`.
+
 ## Docker
-A `docker-compose.yml` runs the Rust server alongside a Postgres database. The client is run locally without Docker.
+A `docker-compose.yml` runs the Rust server alongside Postgres and MinIO. The client is run locally without Docker.
 
 ## Notes
 This project is an early prototype demonstrating login, server selection, text chat and a stub for voice communication via WebRTC.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,33 @@ services:
       POSTGRES_DB: murmer
     volumes:
       - db_data:/var/lib/postgresql/data
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
   server:
     build: ./murmer_server
     restart: unless-stopped
     environment:
       DATABASE_URL: postgres://murmer:murmer@db:5432/murmer
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_BUCKET: murmer
+      MINIO_PUBLIC_URL: http://localhost:9000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
     depends_on:
       - db
+      - minio
     ports:
       - "3001:3001"
 volumes:
   db_data:
+  minio_data:

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-axum = { version = "0.7", features = ["ws"] }
+axum = { version = "0.7", features = ["ws", "multipart"] }
 tokio = { version = "1", features = ["full"] }
 hyper = "1"
 tracing-subscriber = "0.3"
@@ -12,3 +12,6 @@ tracing = "0.1"
 futures = "0.3"
 tokio-postgres = "0.7"
 serde_json = "1"
+aws-config = "1"
+aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }


### PR DESCRIPTION
## Summary
- support multipart uploads to MinIO in the server
- expose `/upload` API endpoint
- allow selecting images in the chat UI and sending them
- document MinIO configuration
- use MinIO container in `docker-compose.yml`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686a99201ee88327a87933fc9874c964