### PR TITLE
Fix compile error due to ByteStream import

### DIFF
--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -1,5 +1,5 @@
 use aws_config;
-use aws_sdk_s3::{Client as S3Client, types::ByteStream};
+use aws_sdk_s3::{Client as S3Client, primitives::ByteStream};
 use axum::{
     Json, Router,
     extract::{
@@ -168,11 +168,11 @@ async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<AppState>>) ->
 
 async fn upload(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
     while let Ok(Some(field)) = multipart.next_field().await {
+        let filename = field
+            .file_name()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "upload".to_string());
         if let Ok(data) = field.bytes().await {
-            let filename = field
-                .file_name()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "upload".to_string());
             let key = format!("{}-{}", chrono::Utc::now().timestamp_millis(), filename);
             let body = ByteStream::from(data.to_vec());
             match state


### PR DESCRIPTION
## Summary
- update S3 ByteStream import to new location
- fix upload handler to store filename before consuming multipart field

## Testing
- `cargo build --manifest-path murmer_server/Cargo.toml`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686a9e73c94c832784717adbb24a8a04