### PR TITLE
Remove MinIO and store uploads locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This launches the desktop app.
 ### Prerequisite
 Docker is required to host a server.
 
-Use Docker Compose to run the server together with Postgres and MinIO:
+Use Docker Compose to run the server together with Postgres:
 ```bash
 docker compose up --build
 ```
@@ -28,23 +28,12 @@ The `DATABASE_URL` used by the server is defined in `docker-compose.yml`.
 
 ### Image Uploads
 
-The server stores uploaded images in a MinIO bucket. Configure the following environment variables when running the server:
+Uploaded images are stored on disk under an `uploads/` directory. Set `PUBLIC_URL` to the base URL clients use to access files (defaults to `http://localhost:3001`). Files can then be fetched from `<PUBLIC_URL>/files/<filename>`.
 
-```
-MINIO_ENDPOINT=<http://localhost:9000>
-MINIO_BUCKET=<bucket-name>
-MINIO_PUBLIC_URL=<public-base-url>
-AWS_ACCESS_KEY_ID=<access-key>
-AWS_SECRET_ACCESS_KEY=<secret-key>
-AWS_REGION=<aws-region>
-```
-
-`MINIO_PUBLIC_URL` should be the base URL clients use to access objects. The server creates the bucket at startup if it doesn't already exist.
-
-`docker-compose.yml` starts a MinIO instance with the default `minioadmin` credentials and uses a bucket named `murmer`.
+`docker-compose.yml` mounts a volume for the uploads directory so files persist between restarts.
 
 ## Docker
-A `docker-compose.yml` runs the Rust server alongside Postgres and MinIO. The client is run locally without Docker.
+A `docker-compose.yml` runs the Rust server alongside Postgres. The client is run locally without Docker.
 
 ## Notes
 This project is an early prototype demonstrating login, server selection, text chat and a stub for voice communication via WebRTC.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,34 +8,19 @@ services:
       POSTGRES_DB: murmer
     volumes:
       - db_data:/var/lib/postgresql/data
-  minio:
-    image: minio/minio:latest
-    command: server /data --console-address ":9001"
-    restart: unless-stopped
-    environment:
-      MINIO_ROOT_USER: Sicheres
-      MINIO_ROOT_PASSWORD: Passwort
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - minio_data:/data
   server:
     build: ./murmer_server
     restart: unless-stopped
     environment:
       DATABASE_URL: postgres://murmer:murmer@db:5432/murmer
-      MINIO_ENDPOINT: http://minio:9000
-      MINIO_BUCKET: murmer
-      MINIO_PUBLIC_URL: http://localhost:9000
-      AWS_ACCESS_KEY_ID: Sicheres
-      AWS_SECRET_ACCESS_KEY: Passwort
-      AWS_REGION: us-east-1
+      PUBLIC_URL: http://localhost:3001
+      UPLOAD_DIR: /app/uploads
     depends_on:
       - db
-      - minio
     ports:
       - "3001:3001"
+    volumes:
+      - uploads:/app/uploads
 volumes:
   db_data:
-  minio_data:
+  uploads:

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -12,6 +12,5 @@ tracing = "0.1"
 futures = "0.3"
 tokio-postgres = "0.7"
 serde_json = "1"
-aws-config = "1"
-aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+tower-http = { version = "0.5", features = ["fs"] }


### PR DESCRIPTION
## Summary
- remove MinIO service from docker-compose
- store uploaded files on disk and serve them from `/files`
- drop S3 code and add local upload handling
- update README with new instructions

## Testing
- `cargo fmt --manifest-path murmer_server/Cargo.toml -- --check`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686ab85c0890832790ef80b7e619f4f2