### PR TITLE
Fix image URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `DATABASE_URL` used by the server is defined in `docker-compose.yml`.
 
 ### Image Uploads
 
-Uploaded images are stored on disk under an `uploads/` directory. Set `PUBLIC_URL` to the base URL clients use to access files (defaults to `http://localhost:3001`). Files can then be fetched from `<PUBLIC_URL>/files/<filename>`.
+Uploaded images are stored on disk under an `uploads/` directory. The `/upload` endpoint returns a relative path like `/files/<filename>` which clients combine with the server URL to load the image.
 
 `docker-compose.yml` mounts a volume for the uploads directory so files persist between restarts.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     restart: unless-stopped
     environment:
       DATABASE_URL: postgres://murmer:murmer@db:5432/murmer
-      PUBLIC_URL: http://localhost:3001
       UPLOAD_DIR: /app/uploads
     depends_on:
       - db

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -71,7 +71,9 @@
       }
       const data = await res.json();
       if (import.meta.env.DEV) console.log('Upload response data:', data);
-      chat.sendRaw({ type: 'chat', user: $session.user ?? 'anon', image: data.url });
+      const url = data.url as string;
+      const img = url.startsWith('http') ? url : base + url;
+      chat.sendRaw({ type: 'chat', user: $session.user ?? 'anon', image: img });
     } catch (e) {
       console.error('upload failed', e);
     } finally {

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -83,7 +83,6 @@ struct AppState {
     users: Arc<Mutex<HashSet<String>>>,
     voice_users: Arc<Mutex<HashSet<String>>>,
     upload_dir: PathBuf,
-    public_url: String,
 }
 
 #[tokio::main]
@@ -128,7 +127,6 @@ ALTER TABLE messages
         .await
         .unwrap();
 
-    let public_url = env::var("PUBLIC_URL").unwrap_or_else(|_| "http://localhost:3001".to_string());
     let upload_dir = env::var("UPLOAD_DIR").unwrap_or_else(|_| "uploads".to_string());
     if let Err(e) = tokio::fs::create_dir_all(&upload_dir).await {
         panic!("create uploads dir: {e}");
@@ -141,7 +139,6 @@ ALTER TABLE messages
         users: Arc::new(Mutex::new(HashSet::new())),
         voice_users: Arc::new(Mutex::new(HashSet::new())),
         upload_dir: PathBuf::from(upload_dir.clone()),
-        public_url,
     });
 
     let app = Router::new()
@@ -172,7 +169,7 @@ async fn upload(State(state): State<Arc<AppState>>, mut multipart: Multipart) ->
             let path = state.upload_dir.join(&key);
             match tokio::fs::write(&path, &data).await {
                 Ok(_) => {
-                    let url = format!("{}/files/{}", state.public_url.trim_end_matches('/'), key);
+                    let url = format!("/files/{}", key);
                     return Json(serde_json::json!({"url": url})).into_response();
                 }
                 Err(e) => {


### PR DESCRIPTION
## Summary
- serve uploaded image URLs as relative paths
- handle relative upload URLs in the chat client
- update README and docker-compose documentation

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686c05a7eb388327b57c3339b5b0f958