### PR TITLE
Fix image upload display

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -149,7 +149,13 @@
             <b>{msg.user}:</b>
             {#if msg.text}{msg.text}{/if}
             {#if msg.image}
-              <img src={msg.image as string} alt="" class="max-w-xs block mt-1" />
+              <a
+                href={msg.image as string}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="block text-blue-600 underline mt-1"
+                >{msg.image}</a
+              >
             {/if}
           </div>
         {/each}


### PR DESCRIPTION
## Summary
- show uploaded image URLs in the chat instead of trying to embed them

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686c0ae44f748327a0f9da888b81b346