### PR TITLE
Enable CORS for image uploads

### DIFF
--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -13,4 +13,4 @@ futures = "0.3"
 tokio-postgres = "0.7"
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-tower-http = { version = "0.5", features = ["fs"] }
+tower-http = { version = "0.5", features = ["fs", "cors"] }

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -19,6 +19,7 @@ use std::{
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, broadcast};
 use tokio_postgres::{Client, NoTls};
+use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 use tracing::{error, info};
 use tracing_subscriber;
@@ -144,10 +145,13 @@ ALTER TABLE messages
         public_url,
     });
 
+    let cors = CorsLayer::permissive();
+
     let app = Router::new()
         .route("/ws", get(ws_handler))
         .route("/upload", post(upload))
         .nest_service("/files", ServeDir::new(upload_dir))
+        .layer(cors)
         .with_state(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3001));


### PR DESCRIPTION
## Summary
- allow CORS requests to the upload endpoint

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686c0d41d3f88327bebea5c5e2e121f7