### PR TITLE
Add settings window with audio options

### DIFF
--- a/murmer_client/src/lib/stores/settings.ts
+++ b/murmer_client/src/lib/stores/settings.ts
@@ -1,0 +1,27 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+interface SettingsState {
+  volume: number;
+  inputDeviceId: string;
+}
+
+const VOLUME_KEY = 'murmer_volume';
+const INPUT_KEY = 'murmer_input_device';
+
+const initialState: SettingsState = {
+  volume: browser ? parseFloat(localStorage.getItem(VOLUME_KEY) ?? '1') : 1,
+  inputDeviceId: browser ? localStorage.getItem(INPUT_KEY) ?? '' : ''
+};
+
+export const settings = writable<SettingsState>(initialState);
+
+settings.subscribe((s) => {
+  if (!browser) return;
+  localStorage.setItem(VOLUME_KEY, s.volume.toString());
+  if (s.inputDeviceId) {
+    localStorage.setItem(INPUT_KEY, s.inputDeviceId);
+  } else {
+    localStorage.removeItem(INPUT_KEY);
+  }
+});

--- a/murmer_client/src/lib/stores/voice.ts
+++ b/murmer_client/src/lib/stores/voice.ts
@@ -1,6 +1,7 @@
-import { writable, derived } from "svelte/store";
+import { writable, derived, get } from "svelte/store";
 import type { Message } from "./chat";
 import { chat } from "./chat";
+import { settings } from "./settings";
 
 export interface RemotePeer {
 	id: string;
@@ -153,8 +154,12 @@ function createVoiceStore() {
 		chat.on("voice-answer", handleAnswer);
 		chat.on("voice-candidate", handleCandidate);
 		chat.on("voice-leave", handleLeave);
-		localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-		chat.sendRaw({ type: "voice-join", user });
+                const deviceId = get(settings).inputDeviceId;
+                const constraints: MediaStreamConstraints = {
+                        audio: deviceId ? { deviceId: { exact: deviceId } } : true
+                };
+                localStream = await navigator.mediaDevices.getUserMedia(constraints);
+                chat.sendRaw({ type: "voice-join", user });
 	}
 
 	function leave() {

--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -1,5 +1,27 @@
 <script lang="ts">
   import '../app.css';
+  import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+
+  async function openSettings() {
+    const existing = await WebviewWindow.getByLabel('settings');
+    if (existing) {
+      await existing.show();
+      await existing.setFocus();
+    } else {
+      new WebviewWindow('settings', {
+        url: '/settings',
+        width: 400,
+        height: 300,
+        title: 'Settings'
+      });
+    }
+  }
 </script>
+
+<div class="fixed top-2 right-2">
+  <button class="bg-gray-200 px-2 py-1 rounded" on:click={openSettings} title="Settings">
+    ⚙️
+  </button>
+</div>
 
 <slot />

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -3,6 +3,7 @@
   import { chat } from '$lib/stores/chat';
   import { session } from '$lib/stores/session';
   import { voice, voiceStats } from '$lib/stores/voice';
+  import { settings } from '$lib/stores/settings';
   import { selectedServer } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
   import { voiceUsers } from '$lib/stores/voiceUsers';
@@ -187,7 +188,7 @@
       {/if}
 
       {#each $voice as peer (peer.id)}
-        <audio autoplay use:stream={peer.stream}></audio>
+        <audio autoplay use:stream={peer.stream} volume={$settings.volume}></audio>
       {/each}
     </div>
     <div class="w-48 p-4 border-l overflow-y-auto">

--- a/murmer_client/src/routes/settings/+page.svelte
+++ b/murmer_client/src/routes/settings/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { get } from 'svelte/store';
+import { settings } from '$lib/stores/settings';
+
+let devices: MediaDeviceInfo[] = [];
+let selected = '';
+let volume = 1;
+
+  onMount(async () => {
+    const initial = get(settings);
+    selected = initial.inputDeviceId;
+    volume = initial.volume;
+    try {
+      const list = await navigator.mediaDevices.enumerateDevices();
+      devices = list.filter((d) => d.kind === 'audioinput');
+    } catch (e) {
+      console.error('enumerateDevices failed', e);
+    }
+  });
+
+  $: settings.update((s) => {
+    const changed =
+      s.inputDeviceId !== selected || s.volume !== volume;
+    return changed ? { ...s, inputDeviceId: selected, volume } : s;
+  });
+</script>
+
+<div class="p-4 space-y-4">
+  <h1 class="text-xl font-bold">Settings</h1>
+
+  <div>
+    <label class="block mb-1" for="volume">Output Volume</label>
+    <input id="volume" type="range" min="0" max="1" step="0.01" bind:value={volume} class="w-full" />
+  </div>
+
+  <div>
+    <label class="block mb-1" for="mic">Input Device</label>
+    <select id="mic" bind:value={selected} class="border p-2 rounded w-full">
+      <option value="">Default</option>
+      {#each devices as d}
+        <option value={d.deviceId}>{d.label || d.deviceId}</option>
+      {/each}
+    </select>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add settings store for volume and microphone selection
- open new settings window from layout
- implement settings page with volume slider and input selector
- apply selected device in voice store and volume in chat

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686c31e742748327834f2849d26584c8