### PR TITLE
Add settings modal and buttons

### DIFF
--- a/murmer_client/src/lib/components/SettingsModal.svelte
+++ b/murmer_client/src/lib/components/SettingsModal.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let open: boolean;
+  export let close: () => void;
+</script>
+
+{#if open}
+  <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+    <div class="bg-white p-4 rounded shadow w-80">
+      <h2 class="text-lg font-bold mb-2">Settings</h2>
+      <p>Settings go here...</p>
+      <button class="mt-4 px-4 py-2 bg-blue-500 text-white rounded" on:click={close}>
+        Close
+      </button>
+    </div>
+  </div>
+{/if}

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -9,6 +9,7 @@
   import { get } from 'svelte/store';
   import { goto } from '$app/navigation';
   import ConnectionBars from '$lib/components/ConnectionBars.svelte';
+  import SettingsModal from '$lib/components/SettingsModal.svelte';
   function strength(user: string): number {
     const stats = get(voiceStats)[user];
     return stats ? stats.strength : 0;
@@ -16,6 +17,7 @@
   let message = '';
   let fileInput: HTMLInputElement;
   let inVoice = false;
+  let settingsOpen = false;
   const channels = ['general', 'random'];
   let currentChannel = 'general';
 
@@ -113,6 +115,14 @@
     goto('/login');
   }
 
+  function openSettings() {
+    settingsOpen = true;
+  }
+
+  function closeSettings() {
+    settingsOpen = false;
+  }
+
   let messagesContainer: HTMLDivElement;
   let lastLength = 0;
 
@@ -130,10 +140,11 @@
         <h1 class="text-xl font-bold">Text Channel</h1>
         <div class="space-x-2 flex items-center">
           <span class="text-sm">{$session.user}</span>
-          <button class="bg-gray-300 px-2 py-1 rounded" on:click={logout}
-            >Logout</button>
+          <button class="bg-gray-300 px-2 py-1 rounded" on:click={openSettings}>Settings</button>
+          <button class="bg-gray-300 px-2 py-1 rounded" on:click={logout}>Logout</button>
         </div>
       </div>
+      <SettingsModal open={settingsOpen} close={closeSettings} />
       <div class="mb-4 space-x-2">
         {#each channels as ch}
           <button

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -4,6 +4,7 @@
   import { session } from '$lib/stores/session';
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
+  import SettingsModal from '$lib/components/SettingsModal.svelte';
 
   onMount(() => {
     if (!get(session).user) goto('/login');
@@ -11,6 +12,7 @@
 
   let newServer = '';
   let newName = '';
+  let settingsOpen = false;
 
   function normalize(input: string): string {
     let url = input.trim();
@@ -45,6 +47,14 @@
     session.set({ user: null });
     goto('/login');
   }
+
+  function openSettings() {
+    settingsOpen = true;
+  }
+
+  function closeSettings() {
+    settingsOpen = false;
+  }
 </script>
 
 <div class="p-4">
@@ -52,9 +62,11 @@
     <h1 class="text-xl font-bold">Servers</h1>
     <div class="space-x-2 flex items-center">
       <span class="text-sm">{$session.user}</span>
+      <button class="bg-gray-300 px-2 py-1 rounded" on:click={openSettings}>Settings</button>
       <button class="bg-gray-300 px-2 py-1 rounded" on:click={logout}>Logout</button>
     </div>
   </div>
+  <SettingsModal open={settingsOpen} close={closeSettings} />
   <div class="mb-4 flex space-x-2">
     <input class="border p-2 rounded flex-1" bind:value={newName} placeholder="Server name" />
     <input class="border p-2 rounded flex-1" bind:value={newServer} placeholder="host:port or ws://url" />


### PR DESCRIPTION
## Summary
- add basic `SettingsModal.svelte` component
- add Settings buttons beside Logout in chat and servers pages
- show modal when the new Settings button is clicked

## Testing
- `npm run check`
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_686d5fa5100083278d21a966941a0410