### PR TITLE
Add volume slider

### DIFF
--- a/murmer_client/src/lib/components/SettingsModal.svelte
+++ b/murmer_client/src/lib/components/SettingsModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { volume } from '$lib/stores/settings';
   export let open: boolean;
   export let close: () => void;
 </script>
@@ -7,7 +8,20 @@
   <div class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
     <div class="bg-white p-4 rounded shadow w-80">
       <h2 class="text-lg font-bold mb-2">Settings</h2>
-      <p>Settings go here...</p>
+      <div class="mb-4">
+        <label for="volume-slider" class="block text-sm mb-1"
+          >Volume: {Math.round($volume * 100)}</label
+        >
+        <input
+          id="volume-slider"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          bind:value={$volume}
+          class="w-full"
+        />
+      </div>
       <button class="mt-4 px-4 py-2 bg-blue-500 text-white rounded" on:click={close}>
         Close
       </button>

--- a/murmer_client/src/lib/stores/settings.ts
+++ b/murmer_client/src/lib/stores/settings.ts
@@ -1,0 +1,21 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'murmer_volume';
+
+let initial = 1;
+if (browser) {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored !== null) {
+    const num = parseFloat(stored);
+    if (!isNaN(num)) initial = num;
+  }
+}
+
+export const volume = writable(initial);
+
+volume.subscribe((value) => {
+  if (browser) {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }
+});

--- a/murmer_client/src/lib/stores/voice.ts
+++ b/murmer_client/src/lib/stores/voice.ts
@@ -1,6 +1,7 @@
 import { writable, derived } from "svelte/store";
 import type { Message } from "./chat";
 import { chat } from "./chat";
+import { volume } from './settings';
 
 export interface RemotePeer {
 	id: string;
@@ -22,8 +23,12 @@ function createVoiceStore() {
 	let userName: string | null = null;
 
 	// sounds for join/leave events
-	const joinSound = new Audio("/sounds/user_join_voice_sound.mp3");
-	const leaveSound = new Audio("/sounds/user_leave_voice_sound.mp3");
+        const joinSound = new Audio("/sounds/user_join_voice_sound.mp3");
+        const leaveSound = new Audio("/sounds/user_leave_voice_sound.mp3");
+        volume.subscribe((v) => {
+                joinSound.volume = v;
+                leaveSound.volume = v;
+        });
 
 	const config: RTCConfiguration = {
 		iceServers: [{ urls: "stun:stun.l.google.com:19302" }],

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -6,6 +6,7 @@
   import { selectedServer } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
   import { voiceUsers } from '$lib/stores/voiceUsers';
+  import { volume } from '$lib/stores/settings';
   import { get } from 'svelte/store';
   import { goto } from '$app/navigation';
   import ConnectionBars from '$lib/components/ConnectionBars.svelte';
@@ -23,9 +24,15 @@
 
   function stream(node: HTMLAudioElement, media: MediaStream) {
     node.srcObject = media;
+    const unsub = volume.subscribe((v) => {
+      node.volume = v;
+    });
     return {
       update(newStream: MediaStream) {
         node.srcObject = newStream;
+      },
+      destroy() {
+        unsub();
       }
     };
   }


### PR DESCRIPTION
## Summary
- add settings store with a persistent `volume`
- show a volume slider in `SettingsModal`
- apply the volume to join/leave sounds
- use the selected volume for all voice streams

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686ecbcc6fc0832792a06e5cfd703be8