### PR TITLE
Improve server docs and code comments

### DIFF
--- a/murmer_server/README.md
+++ b/murmer_server/README.md
@@ -8,3 +8,11 @@ This directory contains the WebSocket server built with Axum. The code is split 
 - `upload.rs` – multipart file upload endpoint.
 
 Run the server with `cargo run` or use the Docker Compose setup from the repository root.
+
+## Environment
+The server reads the following environment variables:
+
+- `DATABASE_URL` – PostgreSQL connection string
+- `UPLOAD_DIR` – directory where uploaded files are stored (defaults to `uploads`)
+
+These are configured automatically when running via `docker compose`.


### PR DESCRIPTION
## Summary
- document environment variables for the server
- add documentation comments for `AppState` and clarify required env vars
- document how the voice store works and key functions

## Testing
- `npm run check`
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_6870282f9be88327b98b3ef8a7b70879