### PR TITLE
Modern dark-theme redesign

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -4,6 +4,7 @@ export interface Message {
   type: string;
   user: string;
   text?: string;
+  time?: string;
   [key: string]: unknown;
 }
 
@@ -33,6 +34,7 @@ function createChatStore() {
       try {
         const msg: Message = JSON.parse(ev.data);
         if (msg.type === 'chat') {
+          if (!msg.time) msg.time = new Date().toLocaleTimeString();
           update((m) => [...m, msg]);
         } else if (msg.type && handlers[msg.type]) {
           handlers[msg.type](msg);
@@ -50,8 +52,9 @@ function createChatStore() {
 
   function send(user: string, text: string) {
     if (socket && socket.readyState === WebSocket.OPEN) {
-      if (import.meta.env.DEV) console.log('Sending:', { user, text });
-      socket.send(JSON.stringify({ type: 'chat', user, text }));
+      const payload = { type: 'chat', user, text, time: new Date().toLocaleTimeString() };
+      if (import.meta.env.DEV) console.log('Sending:', payload);
+      socket.send(JSON.stringify(payload));
     }
   }
 

--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -2,11 +2,35 @@
   const version = '2025.7.9-alpha.1';
 </script>
 
-<slot />
+<style global>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto:wght@400;500&display=swap');
 
-<div class="version">{version}</div>
+  :root {
+    --color-bg: #1e1e2e;
+    --color-panel: #252537;
+    --color-accent: #7c3aed;
+    --color-accent-alt: #2563eb;
+    --color-text: #e2e8f0;
+  }
 
-<style>
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: 'Inter', 'Roboto', sans-serif;
+  }
+
+  button, input, textarea {
+    font-family: inherit;
+    border-radius: 4px;
+  }
+
+  a {
+    color: var(--color-accent-alt);
+  }
+
   .version {
     position: fixed;
     bottom: 0.5rem;
@@ -15,3 +39,7 @@
     font-size: 0.8rem;
   }
 </style>
+
+<slot />
+
+<div class="version">{version}</div>

--- a/murmer_client/src/routes/login/+page.svelte
+++ b/murmer_client/src/routes/login/+page.svelte
@@ -18,8 +18,42 @@
   }
 </script>
 
-<div>
+<div class="login-container">
   <h1>Login</h1>
   <input bind:value={username} placeholder="Username" />
   <button on:click={login}>Login</button>
 </div>
+
+<style>
+  .login-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 300px;
+    margin: 20vh auto 0;
+    padding: 1.5rem;
+    background: var(--color-panel);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  }
+
+  input {
+    padding: 0.5rem;
+    background: #2e2e40;
+    border: 1px solid #444;
+    color: var(--color-text);
+  }
+
+  button {
+    padding: 0.5rem;
+    background: var(--color-accent);
+    border: none;
+    color: white;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+
+  button:hover {
+    background: var(--color-accent-alt);
+  }
+</style>

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -57,7 +57,7 @@
   }
 </script>
 
-<div>
+<div class="servers-page">
   <div class="header">
     <h1>Servers</h1>
     <div class="actions">
@@ -67,27 +67,69 @@
     </div>
   </div>
   <SettingsModal open={settingsOpen} close={closeSettings} />
-  <div>
+  <div class="add">
     <input bind:value={newName} placeholder="Server name" />
     <input bind:value={newServer} placeholder="host:port or ws://url" />
     <button on:click={add}>Add</button>
   </div>
-  <ul>
+  <ul class="list">
     {#each $servers as server}
       <li>
-        <button
-          on:click={() => join(server)}
-          title={server.url}
-        >
-          {server.name}
-        </button>
-        <button on:click={() => removeServer(server.url)}>Delete</button>
+        <button on:click={() => join(server)} title={server.url}>{server.name}</button>
+        <button class="del" on:click={() => removeServer(server.url)}>Delete</button>
       </li>
     {/each}
   </ul>
 </div>
 
 <style>
+  .servers-page {
+    max-width: 500px;
+    margin: 2rem auto;
+    padding: 1rem;
+    background: var(--color-panel);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  }
+
+  .add {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  input {
+    padding: 0.4rem;
+    background: #2e2e40;
+    border: 1px solid #444;
+    color: var(--color-text);
+    flex: 1;
+  }
+
+  button {
+    padding: 0.4rem 0.6rem;
+    background: var(--color-accent);
+    border: none;
+    color: white;
+    cursor: pointer;
+    transition: background 0.2s ease;
+  }
+
+  button.del {
+    background: #b91c1c;
+  }
+
+  button:hover {
+    background: var(--color-accent-alt);
+  }
+
+  .list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.25rem;
+  }
+
   .header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- globally style client with a dark theme and new fonts
- restyle login and server pages
- overhaul chat layout with modern look and floating join button
- store message timestamps and display them

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6871699acd7c8327bb26b9b3f7f760b5