### PR TITLE
Fix unused CSS warnings

### DIFF
--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -2,10 +2,10 @@
   const version = '2025.7.9-alpha.1';
 </script>
 
-<style global>
+<style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto:wght@400;500&display=swap');
 
-  :root {
+  :global(:root) {
     --color-bg: #1e1e2e;
     --color-panel: #252537;
     --color-accent: #7c3aed;
@@ -13,7 +13,8 @@
     --color-text: #e2e8f0;
   }
 
-  html, body {
+  :global(html),
+  :global(body) {
     margin: 0;
     padding: 0;
     height: 100%;
@@ -22,12 +23,14 @@
     font-family: 'Inter', 'Roboto', sans-serif;
   }
 
-  button, input, textarea {
+  :global(button),
+  :global(input),
+  :global(textarea) {
     font-family: inherit;
     border-radius: 4px;
   }
 
-  a {
+  :global(a) {
     color: var(--color-accent-alt);
   }
 


### PR DESCRIPTION
## Summary
- mark global selectors with `:global` in layout

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68716fda1f9c832794739e88620d3d1c