### PR TITLE
Bump version to 2025.7.11-alpha.1

### DIFF
--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmer_client",
-  "version": "2025.7.9-alpha.1",
+  "version": "2025.7.11-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmer_client",
-      "version": "2025.7.9-alpha.1",
+      "version": "2025.7.11-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.6.0",

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmer_client",
-  "version": "2025.7.9-alpha.1",
+  "version": "2025.7.11-alpha.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/murmer_client/src-tauri/Cargo.lock
+++ b/murmer_client/src-tauri/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_client"
-version = "2025.7.9-alpha.1"
+version = "2025.7.11-alpha.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/murmer_client/src-tauri/Cargo.toml
+++ b/murmer_client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_client"
-version = "2025.7.9-alpha.1"
+version = "2025.7.11-alpha.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "murmer_client",
-	"version": "2025.7.9-alpha.1",
+	"version": "2025.7.11-alpha.1",
 	"identifier": "com.murmer-client.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  const version = '2025.7.9-alpha.1';
+  const version = '2025.7.11-alpha.1';
 </script>
 
 <style>

--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_server"
-version = "2025.7.9-alpha.1"
+version = "2025.7.11-alpha.1"
 dependencies = [
  "axum",
  "chrono",

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_server"
-version = "2025.7.9-alpha.1"
+version = "2025.7.11-alpha.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- bump overall version references from `2025.7.9-alpha.1` to `2025.7.11-alpha.1`

## Testing
- `npm run check` in `murmer_client`
- `cargo fmt` in `murmer_server`
- `cargo fmt` in `murmer_client/src-tauri`

------
https://chatgpt.com/codex/tasks/task_e_6871794abaac8327bae7aefeac82338c