### PR TITLE
Limit chat image preview size

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -343,7 +343,8 @@
   }
 
   .content img {
-    max-width: 100%;
+    max-width: min(100%, 500px);
+    max-height: 500px;
     border-radius: 4px;
     margin-top: 0.25rem;
   }


### PR DESCRIPTION
## Summary
- scale down large chat images in preview to at most 500×500px

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68723cd812c88327bd7e78e665093603