### PR TITLE
Fix newline rendering in chat

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -342,6 +342,10 @@
     font-weight: 600;
   }
 
+  .content {
+    white-space: pre-wrap;
+  }
+
   .content img {
     max-width: min(100%, 500px);
     max-height: 500px;


### PR DESCRIPTION
## Summary
- preserve newlines in chat messages

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687241c24f1483279344892db2767be2