### PR TITLE
Set chat username color to pink

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -340,6 +340,7 @@
 
   .username {
     font-weight: 600;
+    color: pink;
   }
 
   .content {


### PR DESCRIPTION
## Summary
- style update to make chat usernames pink

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687247ee6f908327a288cd964f5e1687