### PR TITLE
Fix server reconnect issue

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, afterUpdate, tick } from 'svelte';
+  import { onMount, onDestroy, afterUpdate, tick } from 'svelte';
   import { chat } from '$lib/stores/chat';
   import { session } from '$lib/stores/session';
   import { voice, voiceStats } from '$lib/stores/voice';
@@ -54,6 +54,11 @@
       chat.sendRaw({ type: 'join', channel: currentChannel });
       await scrollBottom();
     });
+  });
+
+  onDestroy(() => {
+    chat.disconnect();
+    voice.leave();
   });
 
   function sendText() {


### PR DESCRIPTION
## Summary
- allow WebSocket reconnections when switching servers
- disconnect sockets when leaving the chat page

## Testing
- `npm run check`
- `cargo fmt --all` in `murmer_server` and `murmer_client/src-tauri`


------
https://chatgpt.com/codex/tasks/task_e_68724bc4bd78832784938c27df0a4912