### PR TITLE
Add leave server button

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -134,6 +134,13 @@
     inVoice = false;
   }
 
+  function leaveServer() {
+    chat.disconnect();
+    voice.leave();
+    selectedServer.set(null);
+    goto('/servers');
+  }
+
   function logout() {
     session.set({ user: null });
     goto('/login');
@@ -181,6 +188,7 @@
         <div class="actions">
           <span class="user">{$session.user}</span>
           <button class="icon" on:click={openSettings} title="Settings">⚙️</button>
+          <button class="icon" on:click={leaveServer} title="Leave Server">⬅️</button>
           <button class="icon" on:click={logout} title="Logout">🚪</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- disconnect from current server via new `leaveServer` function
- add a new icon in chat header to trigger leaving the server

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68724efe06b883278edcc541568d0396