### PR TITLE
Add paginated chat history

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 
 export interface Message {
+  id?: number;
   type: string;
   user: string;
   text?: string;
@@ -13,6 +14,7 @@ function createChatStore() {
   let socket: WebSocket | null = null;
   let currentUrl: string | null = null;
   const handlers: Record<string, (msg: Message) => void> = {};
+  let oldest = Infinity;
 
   function on(type: string, cb: (msg: Message) => void) {
     handlers[type] = cb;
@@ -42,6 +44,7 @@ function createChatStore() {
         if (msg.type === 'chat') {
           if (!msg.time) msg.time = new Date().toLocaleTimeString();
           update((m) => [...m, msg]);
+          if (msg.id !== undefined && msg.id < oldest) oldest = msg.id;
         } else if (msg.type && handlers[msg.type]) {
           handlers[msg.type](msg);
         }
@@ -78,7 +81,32 @@ function createChatStore() {
     }
   }
 
-  return { subscribe, connect, send, sendRaw, on, off, disconnect, clear: () => set([]) };
+  async function loadOlder(channel: string) {
+    if (!currentUrl) return 0;
+    const u = new URL(currentUrl);
+    u.protocol = u.protocol.replace('ws', 'http');
+    if (u.pathname.endsWith('/ws')) u.pathname = u.pathname.slice(0, -3);
+    u.pathname += '/history';
+    u.searchParams.set('channel', channel);
+    u.searchParams.set('before', String(oldest));
+    try {
+      const res = await fetch(u.toString());
+      if (!res.ok) return 0;
+      const msgs: Message[] = await res.json();
+      if (msgs.length) {
+        msgs.forEach((m) => {
+          if (m.id !== undefined && m.id < oldest) oldest = m.id;
+        });
+        update((cur) => [...msgs.reverse(), ...cur]);
+      }
+      return msgs.length;
+    } catch (e) {
+      if (import.meta.env.DEV) console.error('loadOlder failed', e);
+      return 0;
+    }
+  }
+
+  return { subscribe, connect, send, sendRaw, on, off, disconnect, loadOlder, clear: () => { oldest = Infinity; set([]); } };
 }
 
 export const chat = createChatStore();

--- a/murmer_server/src/history.rs
+++ b/murmer_server/src/history.rs
@@ -1,0 +1,35 @@
+use axum::{
+    Json,
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::{AppState, db};
+
+#[derive(Deserialize)]
+pub struct HistoryParams {
+    pub channel: String,
+    pub before: Option<i64>,
+}
+
+pub async fn history(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HistoryParams>,
+) -> impl IntoResponse {
+    let before = params.before.unwrap_or(i64::MAX);
+    let msgs = db::fetch_messages(&state.db, &params.channel, before, 25).await;
+    let out: Vec<Value> = msgs
+        .into_iter()
+        .map(|(id, content)| {
+            let mut v = serde_json::from_str::<Value>(&content).unwrap_or(Value::Null);
+            if let Value::Object(ref mut obj) = v {
+                obj.insert("id".into(), id.into());
+            }
+            v
+        })
+        .collect();
+    Json(out)
+}

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -1,4 +1,5 @@
 mod db;
+mod history;
 mod upload;
 mod ws;
 
@@ -69,6 +70,7 @@ async fn main() {
     let app = Router::new()
         .route("/ws", get(ws::ws_handler))
         .route("/upload", post(upload::upload))
+        .route("/history", get(history::history))
         .nest_service("/files", ServeDir::new(upload_dir))
         .layer(cors)
         .with_state(state);


### PR DESCRIPTION
## Summary
- add an HTTP endpoint for history fetching
- send only the latest 25 messages on join
- allow requesting older messages via the new API
- update the client store and page to load more messages when scrolled to the top
- show a spinner while history is loading

## Testing
- `cargo fmt --manifest-path murmer_server/Cargo.toml`
- `npm run check` in `murmer_client`

------
https://chatgpt.com/codex/tasks/task_e_6872568a6e908327ac40e2f09c273d44