### PR TITLE
Fix duplicate message load

### DIFF
--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "chrono",
  "futures",
  "hyper",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -12,5 +12,6 @@ tracing = "0.1.41"
 futures = "0.3"
 tokio-postgres = "0.7.13"
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tower-http = { version = "0.6.6", features = ["fs", "cors"] }

--- a/murmer_server/src/history.rs
+++ b/murmer_server/src/history.rs
@@ -1,0 +1,35 @@
+use axum::{
+    Json,
+    extract::{Query, State},
+    response::IntoResponse,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::{AppState, db};
+
+#[derive(Deserialize)]
+pub struct HistoryParams {
+    pub channel: String,
+    pub before: Option<i64>,
+}
+
+pub async fn history(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HistoryParams>,
+) -> impl IntoResponse {
+    let before = params.before.unwrap_or(i64::MAX);
+    let msgs = db::fetch_messages(&state.db, &params.channel, before, 25).await;
+    let out: Vec<Value> = msgs
+        .into_iter()
+        .map(|(id, content)| {
+            let mut v = serde_json::from_str::<Value>(&content).unwrap_or(Value::Null);
+            if let Value::Object(ref mut obj) = v {
+                obj.insert("id".into(), id.into());
+            }
+            v
+        })
+        .collect();
+    Json(out)
+}

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -1,4 +1,5 @@
 mod db;
+mod history;
 mod upload;
 mod ws;
 
@@ -69,6 +70,7 @@ async fn main() {
     let app = Router::new()
         .route("/ws", get(ws::ws_handler))
         .route("/upload", post(upload::upload))
+        .route("/history", get(history::history))
         .nest_service("/files", ServeDir::new(upload_dir))
         .layer(cors)
         .with_state(state);


### PR DESCRIPTION
## Summary
- track seen message IDs in chat store
- skip already loaded messages when loading history

## Testing
- `npm run check` in `murmer_client`
- `cargo build` in `murmer_server`

------
https://chatgpt.com/codex/tasks/task_e_6872568a6e908327ac40e2f09c273d44