### PR TITLE
Fix chat duplication on reconnect

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -48,6 +48,7 @@
     }
     const url = get(selectedServer) ?? 'ws://localhost:3001/ws';
     const entry = servers.get(url);
+    chat.clear();
     historyEnd = false;
     loadingHistory = false;
     lastLength = 0;


### PR DESCRIPTION
## Summary
- reset chat messages when entering a server

## Testing
- `npm run check` in `murmer_client`
- `cargo fmt` in `murmer_server`


------
https://chatgpt.com/codex/tasks/task_e_68725ff21540832783d620dfaff37033