### PR TITLE
Fix Postgres id casting

### DIFF
--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -52,7 +52,7 @@ pub async fn fetch_messages(
 ) -> Vec<(i64, String)> {
     if let Ok(rows) = db
         .query(
-            "SELECT id, content FROM messages WHERE channel = $1 AND id < $2 ORDER BY id DESC LIMIT $3",
+            "SELECT id::BIGINT, content FROM messages WHERE channel = $1 AND id < $2 ORDER BY id DESC LIMIT $3",
             &[&channel, &before, &limit],
         )
         .await

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -112,7 +112,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                 match state
                                     .db
                                     .query_one(
-                                        "INSERT INTO messages (channel, content) VALUES ($1, $2) RETURNING id",
+                                        "INSERT INTO messages (channel, content) VALUES ($1, $2) RETURNING id::BIGINT",
                                         &[&channel, &out],
                                     )
                                     .await


### PR DESCRIPTION
## Summary
- cast `messages.id` to BIGINT when querying and inserting

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687263244f2c8327b9210dfaf761b652