### PR TITLE
Fix chat history not displayed on join

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -56,6 +56,7 @@
       const u = get(session).user;
       if (u) chat.sendRaw({ type: 'presence', user: u, password: entry?.password });
       chat.sendRaw({ type: 'join', channel: currentChannel });
+      await chat.loadOlder(currentChannel);
       await scrollBottom();
     });
   });
@@ -118,7 +119,7 @@
     if (hasMessage) sendText();
   }
 
-  function joinChannel(ch: string) {
+  async function joinChannel(ch: string) {
     if (ch === currentChannel) return;
     currentChannel = ch;
     chat.clear();
@@ -126,6 +127,7 @@
     loadingHistory = false;
     lastLength = 0;
     chat.sendRaw({ type: 'join', channel: ch });
+    await chat.loadOlder(ch);
     scrollBottom();
   }
 


### PR DESCRIPTION
## Summary
- ensure chat history loads after connecting
- fetch history after joining another channel

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687266da564083279b3eb5d1e74a295a