### PR TITLE
Fix chat history loading when joining server

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -92,7 +92,9 @@ function createChatStore() {
     if (u.pathname.endsWith('/ws')) u.pathname = u.pathname.slice(0, -3);
     u.pathname += '/history';
     u.searchParams.set('channel', channel);
-    u.searchParams.set('before', String(oldest));
+    if (Number.isFinite(oldest)) {
+      u.searchParams.set('before', String(oldest));
+    }
     try {
       const res = await fetch(u.toString());
       if (!res.ok) return 0;


### PR DESCRIPTION
## Summary
- fix query param for history requests when joining a server

## Testing
- `npm run check` in `murmer_client`
- `cargo fmt` in `murmer_server`


------
https://chatgpt.com/codex/tasks/task_e_687269db5d2c8327bd6662787fae62d4