### PR TITLE
Load entire chat history on connect

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -117,7 +117,6 @@
   function joinChannel(ch: string) {
     if (ch === currentChannel) return;
     currentChannel = ch;
-    chat.clear();
     chat.sendRaw({ type: 'join', channel: ch });
     scrollBottom();
   }
@@ -164,9 +163,12 @@
   let lastLength = 0;
 
   afterUpdate(() => {
-    if (messagesContainer && $chat.length !== lastLength) {
-      lastLength = $chat.length;
-      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    if (messagesContainer) {
+      const filteredLength = $chat.filter(m => (m.channel ?? 'general') === currentChannel).length;
+      if (filteredLength !== lastLength) {
+        lastLength = filteredLength;
+        messagesContainer.scrollTop = messagesContainer.scrollHeight;
+      }
     }
   });
 </script>
@@ -194,7 +196,7 @@
       </div>
       <SettingsModal open={settingsOpen} close={closeSettings} />
       <div class="messages" bind:this={messagesContainer}>
-        {#each $chat as msg}
+        {#each $chat.filter(m => (m.channel ?? 'general') === currentChannel) as msg}
           <div class="message">
             <span class="timestamp">{msg.time}</span>
             <span class="username">{msg.user}</span>

--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -63,3 +63,20 @@ pub async fn send_history(
         }
     }
 }
+
+pub async fn send_all_history(
+    db: &Client,
+    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
+) {
+    if let Ok(rows) = db
+        .query("SELECT content FROM messages ORDER BY id", &[])
+        .await
+    {
+        for row in rows {
+            let content: String = row.get(0);
+            if sender.send(Message::Text(content.into())).await.is_err() {
+                break;
+            }
+        }
+    }
+}

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -56,7 +56,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
 
     let mut authenticated = state.password.is_none();
 
-    db::send_history(&state.db, &mut sender, &channel).await;
+    db::send_all_history(&state.db, &mut sender).await;
     broadcast_voice(&state).await;
 
     loop {
@@ -103,7 +103,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                     channel = ch.to_string();
                                     chan_tx = get_or_create_channel(&state, &channel).await;
                                     chan_rx = chan_tx.subscribe();
-                                    db::send_history(&state.db, &mut sender, &channel).await;
                                 }
                             }
                             "chat" => {


### PR DESCRIPTION
## Summary
- send all stored messages when a client connects
- keep messages in the client when switching channels and filter by channel when displaying
- scroll based on filtered message count

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687279d6814c83279d5a09a4bb7b57ce