### PR TITLE
Add client ping indicator

### DIFF
--- a/murmer_client/src/lib/components/PingDot.svelte
+++ b/murmer_client/src/lib/components/PingDot.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let ping: number = 0;
+  $: color = ping < 100 ? '#22c55e'
+    : ping < 200 ? '#eab308'
+    : ping < 400 ? '#f97316'
+    : '#dc2626';
+</script>
+
+<span class="ping" style="background:{color}" title={`${ping} ms`}></span>
+
+<style>
+  .ping {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    display: inline-block;
+    margin-left: 0.25rem;
+  }
+</style>

--- a/murmer_client/src/lib/stores/ping.ts
+++ b/murmer_client/src/lib/stores/ping.ts
@@ -1,0 +1,41 @@
+import { writable } from 'svelte/store';
+import { chat, type Message } from './chat';
+
+function createPingStore() {
+  const { subscribe, set } = writable(0);
+  let currentId: number | null = null;
+  let interval: number | null = null;
+
+  function sendPing() {
+    if (currentId !== null) return;
+    currentId = Date.now();
+    chat.sendRaw({ type: 'ping', id: currentId });
+  }
+
+  function handlePong(msg: Message) {
+    if (typeof msg.id === 'number' && msg.id === currentId) {
+      set(Date.now() - msg.id);
+      currentId = null;
+    }
+  }
+
+  function start() {
+    stop();
+    chat.on('pong', handlePong);
+    sendPing();
+    interval = window.setInterval(sendPing, 5000);
+  }
+
+  function stop() {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+    chat.off('pong');
+    currentId = null;
+  }
+
+  return { subscribe, start, stop };
+}
+
+export const ping = createPingStore();

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -11,6 +11,8 @@
   import { goto } from '$app/navigation';
   import ConnectionBars from '$lib/components/ConnectionBars.svelte';
   import SettingsModal from '$lib/components/SettingsModal.svelte';
+  import PingDot from '$lib/components/PingDot.svelte';
+  import { ping } from '$lib/stores/ping';
   function strength(user: string): number {
     const stats = get(voiceStats)[user];
     return stats ? stats.strength : 0;
@@ -52,6 +54,7 @@
       const u = get(session).user;
       if (u) chat.sendRaw({ type: 'presence', user: u, password: entry?.password });
       chat.sendRaw({ type: 'join', channel: currentChannel });
+      ping.start();
       await scrollBottom();
     });
   });
@@ -59,6 +62,7 @@
   onDestroy(() => {
     chat.disconnect();
     voice.leave();
+    ping.stop();
   });
 
   function sendText() {
@@ -187,6 +191,7 @@
         <h1>{currentChannel}</h1>
         <div class="actions">
           <span class="user">{$session.user}</span>
+          <PingDot ping={$ping} />
           <button class="icon" on:click={openSettings} title="Settings">⚙️</button>
           <button class="icon" on:click={leaveServer} title="Leave Server">⬅️</button>
           <button class="icon" on:click={logout} title="Logout">🚪</button>

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -121,6 +121,11 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                 }
                                 let _ = chan_tx.send(out);
                             }
+                            "ping" => {
+                                let id = v.get("id").cloned().unwrap_or(Value::Null);
+                                let msg = serde_json::json!({ "type": "pong", "id": id });
+                                let _ = sender.send(Message::Text(msg.to_string())).await;
+                            }
                             "voice-join" => {
                                 if let Some(u) = v.get("user").and_then(|u| u.as_str()) {
                                     let mut voice = state.voice_users.lock().await;


### PR DESCRIPTION
## Summary
- add ping store and dot component in client
- display dot showing server ping in chat header
- support `ping` message in WebSocket server

## Testing
- `npm --prefix murmer_client run check`


------
https://chatgpt.com/codex/tasks/task_e_6872794d1b348327af01858825b96741