### PR TITLE
Fix chat message overflow

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -361,6 +361,7 @@
 
   .content {
     white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 
   .content img {


### PR DESCRIPTION
## Summary
- fix chat message layout so long strings break into new lines

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68727c56ddf883278fda66dbf0b3f8ff