### PR TITLE
Fix Vite fs allow

### DIFF
--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -17,6 +17,7 @@
         "@sveltejs/kit": "^2.22.5",
         "@sveltejs/vite-plugin-svelte": "^6.0.0",
         "@tauri-apps/cli": "^2",
+        "@types/node": "^20.11.0",
         "svelte": "^5.35.5",
         "svelte-check": "^4.2.2",
         "typescript": "~5.8.3",
@@ -1130,6 +1131,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "20.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
+      "integrity": "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1918,6 +1929,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.0.4",

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -20,10 +20,11 @@
     "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^2.22.5",
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
+    "@tauri-apps/cli": "^2",
+    "@types/node": "^20.11.0",
     "svelte": "^5.35.5",
     "svelte-check": "^4.2.2",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4",
-    "@tauri-apps/cli": "^2"
+    "vite": "^7.0.4"
   }
 }

--- a/murmer_client/vite.config.js
+++ b/murmer_client/vite.config.js
@@ -1,8 +1,11 @@
 import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
+
+const rootDir = dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 export default defineConfig(async () => ({
@@ -27,6 +30,9 @@ export default defineConfig(async () => ({
     watch: {
       // 3. tell vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
+    },
+    fs: {
+      allow: [rootDir],
     },
   },
 }));


### PR DESCRIPTION
## Summary
- fix dev server's fs allow list to include project root
- install @types/node for TypeScript

## Testing
- `npm run check` in `murmer_client`


------
https://chatgpt.com/codex/tasks/task_e_68727d2b15788327b0f0c8821203a691