### PR TITLE
Fix repeated chat history on reconnect

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -28,6 +28,7 @@ function createChatStore() {
       socket.close();
       socket = null;
     }
+    set([]); // clear previous history when connecting to a server
     currentUrl = url;
     if (import.meta.env.DEV) console.log('Connecting to WebSocket', url);
     socket = new WebSocket(url);
@@ -76,6 +77,7 @@ function createChatStore() {
       socket.close();
       // 'close' event handler will reset state
     }
+    set([]); // clear chat history on disconnect
   }
 
   return { subscribe, connect, send, sendRaw, on, off, disconnect, clear: () => set([]) };


### PR DESCRIPTION
## Summary
- clear chat store when connecting to a server
- reset chat messages when disconnecting

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68727f5e6fc08327b26d0dbe206cf113