### PR TITLE
Rename Murmer client

### DIFF
--- a/murmer_client/AGENTS.md
+++ b/murmer_client/AGENTS.md
@@ -1,4 +1,4 @@
-# murmer_client Guide
+# Murmer Client Guide
 
 This directory contains the Tauri/SvelteKit desktop client.
 

--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "murmer_client",
+  "name": "murmer",
   "version": "2025.7.12-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "murmer_client",
+      "name": "murmer",
       "version": "2025.7.12-alpha.1",
       "license": "MIT",
       "dependencies": {

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "murmer_client",
+  "name": "murmer",
   "version": "2025.7.12-alpha.1",
   "description": "",
   "type": "module",

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
-	"productName": "murmer_client",
+        "productName": "Murmer",
         "version": "2025.7.12-alpha.1",
-	"identifier": "com.murmer-client.app",
+        "identifier": "com.murmer.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",
 		"devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
         "app": {
                 "windows": [
                         {
-                                "title": "murmer_client",
+                                "title": "Murmer",
                                 "width": 800,
                                 "height": 600
                         }


### PR DESCRIPTION
## Summary
- rename client configuration to display "Murmer" when installed
- adjust the package name used for npm
- update the internal guide accordingly

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687288c6d3808327a8682365444e8e6d