### PR TITLE
fix unused import warning

### DIFF
--- a/murmer_client/src-tauri/src/lib.rs
+++ b/murmer_client/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 use bincode;
 use dirs;
-use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use ed25519_dalek::{Signer, SigningKey};
 use once_cell::sync::OnceCell;
 use rand::rngs::OsRng;
 use std::fs;


### PR DESCRIPTION
## Summary
- remove unused VerifyingKey import from client Rust crate

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6872ce5d8e608327a4624788c4534c69