### PR TITLE
Fix WebSocket drop on ping

### DIFF
--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -88,7 +88,18 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
             Some(result) = receiver.next() => {
                 let text = match result {
                     Ok(Message::Text(t)) => t,
-                    _ => break,
+                    Ok(Message::Ping(p)) => {
+                        let _ = sender.send(Message::Pong(p)).await;
+                        continue;
+                    }
+                    Ok(Message::Pong(_)) => {
+                        continue;
+                    }
+                    Ok(Message::Binary(_)) => {
+                        continue;
+                    }
+                    Ok(Message::Close(_)) => break,
+                    Err(_) => break,
                 };
                 info!("Received message: {text}");
                 if let Ok(mut v) = serde_json::from_str::<Value>(&text) {


### PR DESCRIPTION
## Summary
- keep WebSocket connection alive when clients send Ping/Pong/Binary frames

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6872d0d600c083278fc6248ef41e2b69