### PR TITLE
Implement basic auth and role API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       DATABASE_URL: postgres://murmer:murmer@db:5432/murmer
       UPLOAD_DIR: /app/uploads
+      JWT_SECRET: supersecretkey
       # Uncomment to require a password for WebSocket connections
       # SERVER_PASSWORD: changeme
     depends_on:

--- a/murmer_server/.env.example
+++ b/murmer_server/.env.example
@@ -1,0 +1,5 @@
+# Example configuration
+DATABASE_URL=postgres://murmer:murmer@localhost:5432/murmer
+JWT_SECRET=change-me
+UPLOAD_DIR=uploads
+# SERVER_PASSWORD=optional

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -10,7 +10,13 @@ hyper = "1"
 tracing-subscriber = "0.3.19"
 tracing = "0.1.41"
 futures = "0.3"
-tokio-postgres = "0.7.13"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["serde", "v4"] }
+argon2 = "0.5"
+jsonwebtoken = "9"
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "json", "chrono"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tower-http = { version = "0.6.6", features = ["fs", "cors"] }
+rand = "0.8"
+async-trait = "0.1"

--- a/murmer_server/README.md
+++ b/murmer_server/README.md
@@ -6,8 +6,18 @@ This directory contains the WebSocket server built with Axum. The code is split 
 - `db.rs` – database connection and helper functions such as fetching chat history.
 - `ws.rs` – WebSocket handlers for chat and voice events.
 - `upload.rs` – multipart file upload endpoint.
+- `auth.rs` – REST API for user registration and authentication.
 
 Run the server with `cargo run` or use the Docker Compose setup from the repository root.
+
+### REST API
+The server exposes a small REST API:
+
+- `POST /register` – create a new user
+- `POST /login` – authenticate and receive a JWT
+- `POST /users/:id/roles` – assign a role (requires Owner/Admin)
+- `GET /users` – list all users with their roles
+- `GET /me` – return the authenticated user
 
 ## Environment
 The server reads the following environment variables:
@@ -15,5 +25,6 @@ The server reads the following environment variables:
 - `DATABASE_URL` – PostgreSQL connection string
 - `UPLOAD_DIR` – directory where uploaded files are stored (defaults to `uploads`)
 - `SERVER_PASSWORD` – optional password required to connect via WebSocket
+- `JWT_SECRET` – secret key used to sign authentication tokens
 
 These are configured automatically when running via `docker compose`.

--- a/murmer_server/migrations/001_init.sql
+++ b/murmer_server/migrations/001_init.sql
@@ -1,0 +1,21 @@
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Roles table
+CREATE TABLE IF NOT EXISTS roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT UNIQUE NOT NULL,
+    permissions JSONB NOT NULL
+);
+
+-- Join table
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id UUID REFERENCES users(id),
+    role_id UUID REFERENCES roles(id),
+    PRIMARY KEY (user_id, role_id)
+);

--- a/murmer_server/src/auth.rs
+++ b/murmer_server/src/auth.rs
@@ -1,0 +1,257 @@
+use argon2::{
+    Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+};
+use axum::{
+    Json,
+    extract::{FromRef, FromRequestParts, Path, State},
+    http::{StatusCode, header, request::Parts},
+};
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, Row, types::JsonValue};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::AppState;
+use crate::db::Db;
+
+#[derive(FromRow, Serialize)]
+pub struct User {
+    pub id: Uuid,
+    pub username: String,
+    #[serde(skip_serializing)]
+    pub password_hash: String,
+    #[serde(skip_serializing)]
+    pub created_at: chrono::NaiveDateTime,
+}
+
+#[derive(FromRow, Serialize)]
+pub struct Role {
+    pub id: Uuid,
+    pub name: String,
+    pub permissions: JsonValue,
+}
+
+#[derive(Deserialize)]
+pub struct RegisterInput {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Serialize)]
+struct TokenResponse {
+    token: String,
+}
+
+pub async fn register(
+    State(state): State<AppState>,
+    Json(input): Json<RegisterInput>,
+) -> Result<Json<User>, StatusCode> {
+    let hash = hash_password(&input.password)?;
+    let user = sqlx::query_as::<_, User>(
+        r#"INSERT INTO users (username, password_hash) VALUES ($1, $2) RETURNING id, username, password_hash, created_at"#
+    )
+        .bind(&input.username)
+        .bind(&hash)
+        .fetch_one(&state.db)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    Ok(Json(user))
+}
+
+#[derive(Deserialize)]
+pub struct LoginInput {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: Uuid,
+    exp: usize,
+}
+
+pub async fn login(
+    State(state): State<AppState>,
+    Json(input): Json<LoginInput>,
+) -> Result<Json<TokenResponse>, StatusCode> {
+    let user = sqlx::query_as::<_, User>(
+        r#"SELECT id, username, password_hash, created_at FROM users WHERE username = $1"#,
+    )
+    .bind(&input.username)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    verify_password(&user.password_hash, &input.password)?;
+
+    let claims = Claims {
+        sub: user.id,
+        exp: chrono::Utc::now().timestamp() as usize + 24 * 3600,
+    };
+    let token = jsonwebtoken::encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(state.jwt_secret.as_bytes()),
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(TokenResponse { token }))
+}
+
+// extractor for authenticated user
+pub struct AuthUser {
+    pub id: Uuid,
+}
+
+use async_trait::async_trait;
+
+#[async_trait]
+impl<S> FromRequestParts<S> for AuthUser
+where
+    Arc<AppState>: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let state: Arc<AppState> = Arc::from_ref(state);
+        let auth = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        if !auth.starts_with("Bearer ") {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        let token = &auth[7..];
+        let data = jsonwebtoken::decode::<Claims>(
+            token,
+            &DecodingKey::from_secret(state.jwt_secret.as_bytes()),
+            &Validation::default(),
+        )
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+        Ok(AuthUser {
+            id: data.claims.sub,
+        })
+    }
+}
+
+fn hash_password(pwd: &str) -> Result<String, StatusCode> {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(pwd.as_bytes(), &salt)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        .map(|h| h.to_string())
+}
+
+fn verify_password(hash: &str, pwd: &str) -> Result<(), StatusCode> {
+    let parsed = PasswordHash::new(hash).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Argon2::default()
+        .verify_password(pwd.as_bytes(), &parsed)
+        .map_err(|_| StatusCode::UNAUTHORIZED)
+}
+
+// role assignment
+#[derive(Deserialize)]
+pub struct AssignRole {
+    pub role: Uuid,
+}
+
+pub async fn assign_role(
+    Path(id): Path<Uuid>,
+    State(state): State<AppState>,
+    AuthUser { id: current }: AuthUser,
+    Json(input): Json<AssignRole>,
+) -> Result<StatusCode, StatusCode> {
+    if !user_has_role(&state.db, current, &["Owner", "Admin"]).await? {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    sqlx::query("INSERT INTO user_roles (user_id, role_id) VALUES ($1,$2) ON CONFLICT DO NOTHING")
+        .bind(id)
+        .bind(input.role)
+        .execute(&state.db)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn user_has_role(db: &Db, user: Uuid, roles: &[&str]) -> Result<bool, StatusCode> {
+    let exists: (bool,) = sqlx::query_as(
+        "SELECT EXISTS (SELECT 1 FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.user_id = $1 AND r.name = ANY($2)) as exists"
+    )
+        .bind(user)
+        .bind(roles)
+        .fetch_one(db)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(exists.0)
+}
+
+#[derive(Serialize)]
+pub struct UserWithRoles {
+    pub id: Uuid,
+    pub username: String,
+    pub roles: Vec<String>,
+}
+
+pub async fn list_users(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<UserWithRoles>>, StatusCode> {
+    let rows = sqlx::query(
+        r#"SELECT u.id, u.username, r.name FROM users u
+           LEFT JOIN user_roles ur ON u.id = ur.user_id
+           LEFT JOIN roles r ON ur.role_id = r.id
+           ORDER BY u.username"#,
+    )
+    .fetch_all(&state.db)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut map: std::collections::HashMap<Uuid, UserWithRoles> = std::collections::HashMap::new();
+    for row in rows {
+        let id: Uuid = row.get("id");
+        let entry = map.entry(id).or_insert_with(|| UserWithRoles {
+            id,
+            username: row.get("username"),
+            roles: Vec::new(),
+        });
+        if let Ok(Some(role)) = row.try_get::<Option<String>, _>("name") {
+            entry.roles.push(role);
+        }
+    }
+    Ok(Json(map.into_iter().map(|(_, v)| v).collect()))
+}
+
+pub async fn me(
+    State(state): State<AppState>,
+    AuthUser { id }: AuthUser,
+) -> Result<Json<UserWithRoles>, StatusCode> {
+    let rows = sqlx::query(
+        r#"SELECT u.id, u.username, r.name FROM users u
+           LEFT JOIN user_roles ur ON u.id = ur.user_id
+           LEFT JOIN roles r ON ur.role_id = r.id
+           WHERE u.id = $1"#,
+    )
+    .bind(id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if rows.is_empty() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let mut user = UserWithRoles {
+        id,
+        username: rows[0].get("username"),
+        roles: Vec::new(),
+    };
+    for row in rows {
+        if let Ok(Some(role)) = row.try_get::<Option<String>, _>("name") {
+            user.roles.push(role);
+        }
+    }
+    Ok(Json(user))
+}

--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -1,69 +1,57 @@
-//! Database connection helpers and functions for loading chat history.
-//!
-//! The server persists all chat messages in a single `messages` table with a
-//! `channel` column to distinguish between channels. These helpers create the
-//! table on startup and provide utility functions to fetch history for clients.
-
-use tokio_postgres::{Client, NoTls};
+use axum::extract::ws::{Message, WebSocket};
+use futures::SinkExt;
+use sqlx::{Pool, Postgres, Row, postgres::PgPoolOptions};
 use tracing::warn;
 
-/// Initialize a PostgreSQL [`Client`] and ensure the `messages` table exists.
-/// The connection is retried for a few seconds if the database is not ready.
-pub async fn init(db_url: &str) -> Client {
-    let (client, connection) = {
-        let mut attempts = 0u8;
-        loop {
-            match tokio_postgres::connect(db_url, NoTls).await {
-                Ok(result) => break result,
-                Err(e) if attempts < 30 => {
-                    attempts += 1;
-                    warn!("database not ready ({e}), retrying...");
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                }
-                Err(e) => panic!("connect db: {e}"),
+pub type Db = Pool<Postgres>;
+
+/// Initialize the PostgreSQL connection pool and ensure the `messages` table exists.
+/// Retries for a few seconds if the database is not ready.
+pub async fn init(db_url: &str) -> Db {
+    let mut attempts = 0u8;
+    let pool = loop {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .connect(db_url)
+            .await
+        {
+            Ok(pool) => break pool,
+            Err(e) if attempts < 30 => {
+                attempts += 1;
+                warn!("database not ready ({e}), retrying...");
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
+            Err(e) => panic!("connect db: {e}"),
         }
     };
 
-    tokio::spawn(async move {
-        if let Err(e) = connection.await {
-            eprintln!("db connection error: {e}");
-        }
-    });
-
-    client
-        .batch_execute(
-            r#"CREATE TABLE IF NOT EXISTS messages (
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS messages (
     id SERIAL PRIMARY KEY,
     channel TEXT NOT NULL,
     content TEXT NOT NULL
-);
-"#,
-        )
-        .await
-        .unwrap();
+);"#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
 
-    client
+    pool
 }
-
-use axum::extract::ws::{Message, WebSocket};
-use futures::SinkExt;
 
 /// Send all messages from the given channel over the provided WebSocket.
 pub async fn send_history(
-    db: &Client,
+    db: &Db,
     sender: &mut futures::stream::SplitSink<WebSocket, Message>,
     channel: &str,
 ) {
-    if let Ok(rows) = db
-        .query(
-            "SELECT content FROM messages WHERE channel = $1 ORDER BY id",
-            &[&channel],
-        )
+    if let Ok(rows) = sqlx::query("SELECT content FROM messages WHERE channel = $1 ORDER BY id")
+        .bind(channel)
+        .fetch_all(db)
         .await
     {
         for row in rows {
-            let content: String = row.get(0);
+            let content: String = row.get("content");
             if sender.send(Message::Text(content.into())).await.is_err() {
                 break;
             }
@@ -73,15 +61,15 @@ pub async fn send_history(
 
 /// Send the full message history across all channels.
 pub async fn send_all_history(
-    db: &Client,
+    db: &Db,
     sender: &mut futures::stream::SplitSink<WebSocket, Message>,
 ) {
-    if let Ok(rows) = db
-        .query("SELECT content FROM messages ORDER BY id", &[])
+    if let Ok(rows) = sqlx::query("SELECT content FROM messages ORDER BY id")
+        .fetch_all(db)
         .await
     {
         for row in rows {
-            let content: String = row.get(0);
+            let content: String = row.get("content");
             if sender.send(Message::Text(content.into())).await.is_err() {
                 break;
             }

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -117,13 +117,13 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                             "chat" => {
                                 v["channel"] = Value::String(channel.clone());
                                 let out = serde_json::to_string(&v).unwrap_or_else(|_| text.to_string());
-                                if let Err(e) = state
-                                    .db
-                                    .execute(
-                                        "INSERT INTO messages (channel, content) VALUES ($1, $2)",
-                                        &[&channel, &out],
-                                    )
-                                    .await
+                                if let Err(e) = sqlx::query(
+                                    "INSERT INTO messages (channel, content) VALUES ($1, $2)"
+                                )
+                                .bind(&channel)
+                                .bind(&out)
+                                .execute(&state.db)
+                                .await
                                 {
                                     error!("db insert error: {e}");
                                 }


### PR DESCRIPTION
## Summary
- add auth API and JWT middleware
- store user data with sqlx
- add docker environment setup
- document auth API

## Testing
- `cargo build --manifest-path murmer_server/Cargo.toml` *(fails: lifetime parameters mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68736dcc3fa08327b13cb93ee522c09f