### PR TITLE
Fix postcss error by renaming VERSION constant

### DIFF
--- a/murmer_client/src/lib/components/SettingsModal.svelte
+++ b/murmer_client/src/lib/components/SettingsModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { volume, inputDeviceId, outputDeviceId } from '$lib/stores/settings';
-  import { VERSION } from '$lib/version';
+  import { APP_VERSION } from '$lib/version';
   import { onMount } from 'svelte';
   export let open: boolean;
   export let close: () => void;
@@ -31,9 +31,9 @@
       if (Array.isArray(releases) && releases.length > 0) {
         const stable = releases.find((r) => !r.prerelease);
         const pre = releases.find((r) => r.prerelease);
-        if (pre && pre.tag_name && pre.tag_name !== VERSION) {
+        if (pre && pre.tag_name && pre.tag_name !== APP_VERSION) {
           updateMessage = `Pre-release available: ${pre.tag_name}`;
-        } else if (stable && stable.tag_name && stable.tag_name !== VERSION) {
+        } else if (stable && stable.tag_name && stable.tag_name !== APP_VERSION) {
           updateMessage = `Update available: ${stable.tag_name}`;
         } else {
           updateMessage = 'You are running the latest version.';

--- a/murmer_client/src/lib/version.ts
+++ b/murmer_client/src/lib/version.ts
@@ -1,2 +1,2 @@
 import pkg from '../../package.json';
-export const VERSION = pkg.version as string;
+export const APP_VERSION = pkg.version as string;

--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { VERSION } from '$lib/version';
+  import { APP_VERSION } from '$lib/version';
 </script>
 
 <style>
@@ -45,4 +45,4 @@
 
 <slot />
 
-<div class="version">{VERSION}</div>
+<div class="version">{APP_VERSION}</div>


### PR DESCRIPTION
## Summary
- rename `VERSION` to `APP_VERSION` to avoid potential collision with env vars

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68738d33c36483279d14a88b01a1285d