### PR TITLE
Fix css parsing for layout

### DIFF
--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -2,8 +2,14 @@
   import { APP_VERSION } from '$lib/version';
 </script>
 
+<svelte:head>
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto:wght@400;500&display=swap"
+  />
+</svelte:head>
+
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto:wght@400;500&display=swap');
 
   :global(:root) {
     --color-bg: #1e1e2e;


### PR DESCRIPTION
## Summary
- move Google Fonts import to `<svelte:head>` to avoid PostCSS parsing the script block

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68738f5ae94883279b013752370b8779