### PR TITLE
Add ADMIN_TOKEN env file support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration for Docker Compose
+# Copy this file to `.env` and customize the values as needed.
+
+# Secret token required for the `/role` endpoint
+ADMIN_TOKEN=my-admin-token
+
+# Optional password required for clients to connect
+# SERVER_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ target
 # Contains mutation testing data
 **/mutants.out*/
 
+# Environment overrides
+.env
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,14 @@ services:
   server:
     build: ./murmer_server
     restart: unless-stopped
+    # Load optional settings like ADMIN_TOKEN from a `.env` file
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgres://murmer:murmer@db:5432/murmer
       UPLOAD_DIR: /app/uploads
       # Uncomment to require a password for WebSocket connections
       # SERVER_PASSWORD: changeme
-      # ADMIN_TOKEN: my-admin-token
     depends_on:
       - db
     ports:


### PR DESCRIPTION
## Summary
- load server secrets from a `.env` file
- add `.env.example` placeholder
- ignore `.env` in Git

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6873ba7778f48327b18be1088762c230