### PR TITLE
Bump version to 2025.7.13-alpha.1

### DIFF
--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmer",
-  "version": "2025.7.12-alpha.1",
+  "version": "2025.7.13-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmer",
-      "version": "2025.7.12-alpha.1",
+      "version": "2025.7.13-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.6.0",

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmer",
-  "version": "2025.7.12-alpha.1",
+  "version": "2025.7.13-alpha.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/murmer_client/src-tauri/Cargo.lock
+++ b/murmer_client/src-tauri/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_client"
-version = "2025.7.12-alpha.1"
+version = "2025.7.13-alpha.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/murmer_client/src-tauri/Cargo.toml
+++ b/murmer_client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_client"
-version = "2025.7.12-alpha.1"
+version = "2025.7.13-alpha.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
         "productName": "Murmer",
-        "version": "2025.7.12-alpha.1",
+        "version": "2025.7.13-alpha.1",
         "identifier": "com.murmer.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_server"
-version = "2025.7.12-alpha.1"
+version = "2025.7.13-alpha.1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_server"
-version = "2025.7.12-alpha.1"
+version = "2025.7.13-alpha.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- bump version to `2025.7.13-alpha.1` across client and server

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6873c1e17b288327816f21c882461430