### PR TITLE
Preserve offline role mappings

### DIFF
--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -270,11 +270,8 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
         } else {
             drop(voice);
         }
-        let mut roles = state.roles.lock().await;
-        roles.remove(&name);
-        drop(roles);
-        let mut keys = state.user_keys.lock().await;
-        keys.remove(&name);
+        // Keep role and key mappings so clients can display roles
+        // even when the user is offline.
     }
     info!("Client disconnected");
 }


### PR DESCRIPTION
## Summary
- keep user role and key records when a client disconnects

## Testing
- `cargo fmt --manifest-path murmer_server/Cargo.toml`
- `npm run check` in `murmer_client`


------
https://chatgpt.com/codex/tasks/task_e_6873c4022b108327b287b77e2805e117