### PR TITLE
Enable creating channels

### DIFF
--- a/murmer_client/src/lib/stores/channels.ts
+++ b/murmer_client/src/lib/stores/channels.ts
@@ -1,0 +1,29 @@
+import { writable } from 'svelte/store';
+import { chat } from './chat';
+import type { Message } from './chat';
+
+function createChannelStore() {
+  const { subscribe, set, update } = writable<string[]>([]);
+
+  chat.on('channel-list', (msg: Message) => {
+    const list = (msg as any).channels;
+    if (Array.isArray(list)) {
+      set(list as string[]);
+    }
+  });
+
+  chat.on('channel-add', (msg: Message) => {
+    const name = (msg as any).channel;
+    if (typeof name === 'string') {
+      update((chs) => (chs.includes(name) ? chs : [...chs, name]));
+    }
+  });
+
+  function create(name: string) {
+    chat.sendRaw({ type: 'create-channel', name });
+  }
+
+  return { subscribe, set, create };
+}
+
+export const channels = createChannelStore();

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -14,6 +14,7 @@
   import SettingsModal from '$lib/components/SettingsModal.svelte';
   import PingDot from '$lib/components/PingDot.svelte';
   import { ping } from '$lib/stores/ping';
+  import { channels } from '$lib/stores/channels';
   import { loadKeyPair, sign } from '$lib/keypair';
   function strength(user: string): number {
     const stats = get(voiceStats)[user];
@@ -34,8 +35,12 @@
   $: autoResize();
   let inVoice = false;
   let settingsOpen = false;
-  const channels = ['general', 'random'];
   let currentChannel = 'general';
+
+  $: if ($channels.length && !$channels.includes(currentChannel)) {
+    currentChannel = $channels[0];
+    chat.sendRaw({ type: 'join', channel: currentChannel });
+  }
 
   function isCode(text: string): boolean {
     return /^```[\s\S]*```$/.test(text.trim());
@@ -184,6 +189,12 @@
     goto('/servers');
   }
 
+  function openChannelMenu(event: MouseEvent) {
+    event.preventDefault();
+    const name = prompt('New channel name');
+    if (name) channels.create(name);
+  }
+
   function logout() {
     session.set({ user: null });
     goto('/login');
@@ -218,8 +229,8 @@
 </script>
 
   <div class="page">
-    <div class="channels">
-      {#each channels as ch}
+    <div class="channels" role="navigation" on:contextmenu={openChannelMenu}>
+      {#each $channels as ch}
         <button
           class:active={ch === currentChannel}
           on:click={() => joinChannel(ch)}


### PR DESCRIPTION
## Summary
- add `channels` store for dynamic list of chat channels
- allow users to create channels from the chat view
- persist channel names on the server and broadcast updates
- send channel list to new connections

## Testing
- `npm run check` within `murmer_client`
- `cargo fmt` within `murmer_server`

------
https://chatgpt.com/codex/tasks/task_e_6873ef5a2bd483279f0363101cc1eb93