### PR TITLE
Add right spacer to chat input

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -274,7 +274,7 @@
           </div>
         {/each}
       </div>
-      <div>
+      <div class="input-row">
         <textarea
           bind:value={message}
           bind:this={messageInput}
@@ -290,6 +290,7 @@
         ></textarea>
         <input type="file" bind:this={fileInput} accept="image/*" />
         <button class="send" on:click={send}>Send</button>
+        <div class="spacer"></div>
       </div>
 
       {#if inVoice}
@@ -401,6 +402,17 @@
     gap: 0.5rem;
     padding-right: 0.5rem;
     padding-bottom: 0.5rem;
+  }
+
+  .input-row {
+    display: flex;
+    padding-right: 0.5rem;
+    align-items: flex-end;
+  }
+
+  .spacer {
+    width: 0.5rem;
+    flex-shrink: 0;
   }
 
   .message {


### PR DESCRIPTION
## Summary
- add `.input-row` container around message input controls
- add `.spacer` element so the textarea has right padding

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687e228eae94832796fbf7a62c80f9db