### PR TITLE
Remove default random channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The server exposes a WebSocket endpoint at `ws://localhost:3001/ws`. The client 
 The `DATABASE_URL` used by the server is defined in `docker-compose.yml`.
 If you set the `SERVER_PASSWORD` environment variable in `docker-compose.yml`, the server will require clients to provide that password when connecting.
 
+On first launch the server creates a single text channel named `general`. Users
+can create additional channels as needed, but no other channels are included by
+default.
+
 ### Admin Roles
 
 The server can assign custom roles to users. To enable this feature set the `ADMIN_TOKEN`

--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -46,7 +46,6 @@ CREATE TABLE IF NOT EXISTS channels (
     name TEXT PRIMARY KEY
 );
 INSERT INTO channels (name) VALUES ('general') ON CONFLICT DO NOTHING;
-INSERT INTO channels (name) VALUES ('random') ON CONFLICT DO NOTHING;
 "#,
         )
         .await


### PR DESCRIPTION
## Summary
- drop random channel from DB init
- document the default `general` channel

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687e22ddaa1c832797ed808de871b120