### PR TITLE
Add offline user tracking

### DIFF
--- a/murmer_client/src/lib/stores/users.ts
+++ b/murmer_client/src/lib/stores/users.ts
@@ -1,0 +1,19 @@
+import { writable, derived } from 'svelte/store';
+import { chat } from './chat';
+import type { Message } from './chat';
+import { onlineUsers } from './online';
+
+function createAllUserStore() {
+  const { subscribe, set } = writable<string[]>([]);
+  chat.on('online-users', (msg: Message) => {
+    if (Array.isArray((msg as any).all)) {
+      set((msg as any).all as string[]);
+    }
+  });
+  return { subscribe };
+}
+
+export const allUsers = createAllUserStore();
+export const offlineUsers = derived([allUsers, onlineUsers], ([$all, $online]) =>
+  $all.filter((u) => !$online.includes(u))
+);

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -6,6 +6,7 @@
   import { voice, voiceStats } from '$lib/stores/voice';
   import { selectedServer, servers } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
+  import { allUsers } from '$lib/stores/users';
   import { voiceUsers } from '$lib/stores/voiceUsers';
   import { volume, outputDeviceId } from '$lib/stores/settings';
   import { get } from 'svelte/store';
@@ -303,10 +304,13 @@
       {/each}
   </div>
   <div class="sidebar">
-      <h2>Online</h2>
+      <h2>Users</h2>
       <ul>
-        {#each $onlineUsers as user}
-          <li><span class="status online"></span>{user}</li>
+        {#each $allUsers as user}
+          <li>
+            <span class="status { $onlineUsers.includes(user) ? 'online' : 'offline' }"></span>
+            <span class:offline={!$onlineUsers.includes(user)}>{user}</span>
+          </li>
         {/each}
       </ul>
       <h2>Voice</h2>
@@ -515,6 +519,14 @@
 
   .status.online {
     background: #22c55e;
+  }
+
+  .status.offline {
+    background: #6b7280;
+  }
+
+  .offline {
+    color: #9ca3af;
   }
 
   .status.voice {

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -25,6 +25,7 @@ use tracing::info;
 /// - `channels`: per-text-channel broadcast senders.
 /// - `db`: PostgreSQL client for persisting chat history.
 /// - `users`: set of currently connected chat users.
+/// - `known_users`: set of all users that have ever joined while the server is running.
 /// - `voice_users`: set of users active in voice chat.
 /// - `upload_dir`: directory where uploaded files are stored.
 pub struct AppState {
@@ -32,6 +33,7 @@ pub struct AppState {
     pub channels: Arc<Mutex<HashMap<String, broadcast::Sender<String>>>>,
     pub db: Arc<tokio_postgres::Client>,
     pub users: Arc<Mutex<HashSet<String>>>,
+    pub known_users: Arc<Mutex<HashSet<String>>>,
     pub voice_users: Arc<Mutex<HashSet<String>>>,
     pub roles: Arc<Mutex<HashMap<String, String>>>,
     pub user_keys: Arc<Mutex<HashMap<String, String>>>,
@@ -64,6 +66,7 @@ async fn main() {
         channels: Arc::new(Mutex::new(HashMap::new())),
         db: Arc::new(db_client),
         users: Arc::new(Mutex::new(HashSet::new())),
+        known_users: Arc::new(Mutex::new(HashSet::new())),
         voice_users: Arc::new(Mutex::new(HashSet::new())),
         roles: Arc::new(Mutex::new(HashMap::new())),
         user_keys: Arc::new(Mutex::new(HashMap::new())),


### PR DESCRIPTION
## Summary
- remember all users that connect to the server
- send full user list along with online users
- show offline users in grey in the chat sidebar

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687e26422cac83279a474a9ee84bc472