### PR TITLE
Use icon for upload button

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -313,7 +313,7 @@
           accept="image/*"
           on:change={handleFileChange}
         />
-        <label for="fileInputElem" class="file-button">Upload</label>
+        <label for="fileInputElem" class="file-button" title="Upload image">🖼️</label>
         {#if previewUrl}
           <img src={previewUrl} alt="preview" class="preview" />
         {/if}


### PR DESCRIPTION
## Summary
- show an image icon on the chat upload button

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687e301bd2048327900095e1f1a9d354