### PR TITLE
Fix user online display

### DIFF
--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -123,6 +123,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
     broadcast_voice(&state).await;
     send_all_roles(&state, &mut sender).await;
     send_channels(&state, &mut sender).await;
+    broadcast_users(&state).await;
 
     loop {
         tokio::select! {


### PR DESCRIPTION
## Summary
- broadcast the online user list to newly connected clients

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687e306e8edc8327a06641e44c91c1c7