### PR TITLE
Refactor client types

### DIFF
--- a/murmer_client/src-tauri/src/lib.rs
+++ b/murmer_client/src-tauri/src/lib.rs
@@ -1,9 +1,3 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     use tauri::{
@@ -64,7 +58,6 @@ pub fn run() {
                     });
             }
         })
-        .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/murmer_client/src/lib/stores/channels.ts
+++ b/murmer_client/src/lib/stores/channels.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import { chat } from './chat';
-import type { Message } from './chat';
+import type { Message } from '../types';
 
 function createChannelStore() {
   const { subscribe, set, update } = writable<string[]>([]);

--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -1,12 +1,5 @@
 import { writable } from 'svelte/store';
-
-export interface Message {
-  type: string;
-  user: string;
-  text?: string;
-  time?: string;
-  [key: string]: unknown;
-}
+import type { Message } from '../types';
 
 function createChatStore() {
   const { subscribe, update, set } = writable<Message[]>([]);

--- a/murmer_client/src/lib/stores/online.ts
+++ b/murmer_client/src/lib/stores/online.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import { chat } from './chat';
-import type { Message } from './chat';
+import type { Message } from '../types';
 
 function createOnlineStore() {
   const { subscribe, set } = writable<string[]>([]);

--- a/murmer_client/src/lib/stores/ping.ts
+++ b/murmer_client/src/lib/stores/ping.ts
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
-import { chat, type Message } from './chat';
+import { chat } from './chat';
+import type { Message } from '../types';
 
 function createPingStore() {
   const { subscribe, set } = writable(0);

--- a/murmer_client/src/lib/stores/roles.ts
+++ b/murmer_client/src/lib/stores/roles.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import { chat } from './chat';
-import type { Message } from './chat';
+import type { Message } from '../types';
 
 function createRoleStore() {
   const { subscribe, update, set } = writable<Record<string, string>>({});

--- a/murmer_client/src/lib/stores/users.ts
+++ b/murmer_client/src/lib/stores/users.ts
@@ -1,6 +1,6 @@
 import { writable, derived } from 'svelte/store';
 import { chat } from './chat';
-import type { Message } from './chat';
+import type { Message } from '../types';
 import { onlineUsers } from './online';
 
 function createAllUserStore() {

--- a/murmer_client/src/lib/stores/voice.ts
+++ b/murmer_client/src/lib/stores/voice.ts
@@ -1,5 +1,5 @@
 import { writable, derived, get } from 'svelte/store';
-import type { RemotePeer, ConnectionStats } from '../voice/manager';
+import type { RemotePeer, ConnectionStats } from '../types';
 import { VoiceManager } from '../voice/manager';
 
 const peers = writable<RemotePeer[]>([]);

--- a/murmer_client/src/lib/stores/voiceUsers.ts
+++ b/murmer_client/src/lib/stores/voiceUsers.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import { chat } from './chat';
-import type { Message } from './chat';
+import type { Message } from '../types';
 
 function createVoiceUserStore() {
   const { subscribe, set } = writable<string[]>([]);

--- a/murmer_client/src/lib/types.ts
+++ b/murmer_client/src/lib/types.ts
@@ -1,0 +1,19 @@
+export interface Message {
+  type: string;
+  user: string;
+  text?: string;
+  time?: string;
+  [key: string]: unknown;
+}
+
+export interface RemotePeer {
+  id: string;
+  stream: MediaStream;
+  stats?: ConnectionStats;
+}
+
+export interface ConnectionStats {
+  rtt: number;
+  jitter: number;
+  strength: number;
+}

--- a/murmer_client/src/lib/voice/manager.ts
+++ b/murmer_client/src/lib/voice/manager.ts
@@ -1,19 +1,7 @@
 import { chat } from '../stores/chat';
 import { volume, inputDeviceId } from '../stores/settings';
 import { get } from 'svelte/store';
-import type { Message } from '../stores/chat';
-
-export interface RemotePeer {
-  id: string;
-  stream: MediaStream;
-  stats?: ConnectionStats;
-}
-
-export interface ConnectionStats {
-  rtt: number;
-  jitter: number;
-  strength: number; // 1-5 bars
-}
+import type { Message, RemotePeer, ConnectionStats } from '../types';
 
 /**
  * Handles WebRTC peer connections and signaling for voice chat.


### PR DESCRIPTION
## Summary
- remove unused Tauri `greet` command
- centralize shared TypeScript interfaces in `src/lib/types.ts`
- update imports to use new shared types

## Testing
- `cargo fmt`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687e4fa796ac832783b9def8eccf0e52