### PR TITLE
Bump version to 2025.7.21-alpha.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,20 @@ Each subfolder contains its own `AGENTS.md` with more details.
 
 ## Docker
 Use `docker compose up --build` to start the server and a Postgres database defined in `docker-compose.yml`.
+
+## Versioning
+Murmer uses date-based pre-release versions such as `2025.7.13-alpha.1`.
+When asked to **bump the version**, follow these steps:
+1. Determine today's date in `YYYY.M.D` format.
+2. If a tag `YYYY.M.D-alpha.1` already exists, increment the numeric
+   suffix (`alpha.2`, `alpha.3`, ...). Otherwise start with `alpha.1`.
+3. Replace the old version in:
+   - `murmer_client/package.json`
+   - `murmer_client/package-lock.json`
+   - `murmer_client/src-tauri/Cargo.toml`
+   - `murmer_client/src-tauri/Cargo.lock`
+   - `murmer_client/src-tauri/tauri.conf.json`
+   - `murmer_server/Cargo.toml`
+   - `murmer_server/Cargo.lock`
+4. Commit the changes with a message like `Bump version to <new version>`
+   and create a git tag with the same version string.

--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmer",
-  "version": "2025.7.13-alpha.1",
+  "version": "2025.7.21-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmer",
-      "version": "2025.7.13-alpha.1",
+      "version": "2025.7.21-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.6.0",

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmer",
-  "version": "2025.7.13-alpha.1",
+  "version": "2025.7.21-alpha.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/murmer_client/src-tauri/Cargo.lock
+++ b/murmer_client/src-tauri/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_client"
-version = "2025.7.13-alpha.1"
+version = "2025.7.21-alpha.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/murmer_client/src-tauri/Cargo.toml
+++ b/murmer_client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_client"
-version = "2025.7.13-alpha.1"
+version = "2025.7.21-alpha.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
         "productName": "Murmer",
-        "version": "2025.7.13-alpha.1",
+        "version": "2025.7.21-alpha.1",
         "identifier": "com.murmer.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_server"
-version = "2025.7.13-alpha.1"
+version = "2025.7.21-alpha.1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_server"
-version = "2025.7.13-alpha.1"
+version = "2025.7.21-alpha.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- bump Murmer version to `2025.7.21-alpha.1`
- document version bump procedure in `AGENTS.md`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687e5c3a0b4c8327bc4bb77d4643a8f1