### PR TITLE
Implement basic OS notifications

### DIFF
--- a/murmer_client/src/lib/notify.ts
+++ b/murmer_client/src/lib/notify.ts
@@ -1,0 +1,13 @@
+import { browser } from '$app/environment';
+
+export async function notify(title: string, body?: string) {
+  if (!browser || typeof Notification === 'undefined') return;
+  if (Notification.permission === 'granted') {
+    new Notification(title, { body });
+  } else if (Notification.permission !== 'denied') {
+    const permission = await Notification.requestPermission();
+    if (permission === 'granted') {
+      new Notification(title, { body });
+    }
+  }
+}

--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -1,5 +1,7 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import type { Message } from '../types';
+import { session } from './session';
+import { notify } from '../notify';
 
 function createChatStore() {
   const { subscribe, update, set } = writable<Message[]>([]);
@@ -47,6 +49,10 @@ function createChatStore() {
         if (msg.type === 'chat') {
           if (!msg.time) msg.time = new Date().toLocaleTimeString();
           update((m) => [...m, msg]);
+          const current = get(session).user;
+          if (!current || msg.user !== current) {
+            notify('New message', `${msg.user}: ${msg.text ?? ''}`);
+          }
         } else if (msg.type && handlers[msg.type]) {
           for (const handler of handlers[msg.type]) {
             handler(msg);


### PR DESCRIPTION
## Summary
- add utility to trigger OS notifications using the browser Notification API
- notify on new chat messages

## Testing
- `npm run check`
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_687e95bbeeb48327b0ce9c062c6621ed