### PR TITLE
Sort users by online state

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -6,7 +6,7 @@
   import { voice, voiceStats } from '$lib/stores/voice';
   import { selectedServer, servers } from '$lib/stores/servers';
   import { onlineUsers } from '$lib/stores/online';
-  import { allUsers } from '$lib/stores/users';
+  import { allUsers, offlineUsers } from '$lib/stores/users';
   import { voiceUsers } from '$lib/stores/voiceUsers';
   import { volume, outputDeviceId } from '$lib/stores/settings';
   import { get } from 'svelte/store';
@@ -369,11 +369,21 @@
   </div>
   <div class="sidebar">
       <h2>Users</h2>
+      <h3>Online</h3>
       <ul>
-        {#each $allUsers as user}
+        {#each $onlineUsers as user}
           <li>
-            <span class="status { $onlineUsers.includes(user) ? 'online' : 'offline' }"></span>
-            <span class:offline={!$onlineUsers.includes(user)}>{user}</span>
+            <span class="status online"></span>
+            <span>{user}</span>
+          </li>
+        {/each}
+      </ul>
+      <h3>Offline</h3>
+      <ul>
+        {#each $offlineUsers as user}
+          <li>
+            <span class="status offline"></span>
+            <span class="offline">{user}</span>
           </li>
         {/each}
       </ul>


### PR DESCRIPTION
## Summary
- group users in chat sidebar into online and offline sections
- import `offlineUsers` store to power offline list

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687ea0513a20832789fb27ffca1c560b