### PR TITLE
Minor UI improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@ Use the checkboxes to track progress.
 - [ ] Direct messages between users
 - [ ] Slash commands for quick actions
 - [ ] Ephemeral messages that auto-delete
+- [ ] Load chat history only for the selected channel
 
 ### 🎤 Voice Features
 
@@ -36,6 +37,7 @@ Use the checkboxes to track progress.
 - [ ] Scheduled voice events / calendar integration
 - [ ] Server invite links
 - [ ] Theme customization (dark/light)
+- [ ] Sanitize uploaded filenames to prevent path traversal
 
 ---
 

--- a/murmer_client/src/routes/login/+page.svelte
+++ b/murmer_client/src/routes/login/+page.svelte
@@ -18,11 +18,11 @@
   }
 </script>
 
-<div class="login-container">
+<form class="login-container" on:submit|preventDefault={login}>
   <h1>Login</h1>
-  <input bind:value={username} placeholder="Username" />
-  <button on:click={login}>Login</button>
-</div>
+  <input bind:value={username} placeholder="Username" autofocus />
+  <button type="submit">Login</button>
+</form>
 
 <style>
   .login-container {

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -61,12 +61,12 @@
     </div>
   </div>
   <SettingsModal open={settingsOpen} close={closeSettings} />
-  <div class="add">
-    <input bind:value={newName} placeholder="Server name" />
+  <form class="add" on:submit|preventDefault={add}>
+    <input bind:value={newName} placeholder="Server name" autofocus />
     <input bind:value={newServer} placeholder="host:port or ws://url" />
     <input type="password" bind:value={newPassword} placeholder="Password (optional)" />
-    <button on:click={add}>Add</button>
-  </div>
+    <button type="submit">Add</button>
+  </form>
   <ul class="list">
     {#each $servers as server}
       <li>


### PR DESCRIPTION
## Summary
- make login form submit on Enter and autofocus username field
- make add server form submit on Enter and autofocus name field
- note ideas for per-channel history and safer uploads in TODO

## Testing
- `npm run check` in `murmer_client`
- `cargo fmt` in `murmer_server`

------
https://chatgpt.com/codex/tasks/task_e_687ea82ffc4c8327bce60f49ca3b69e3