### PR TITLE
Fix path traversal in upload filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ indicating their assigned role.
 
 ### Image Uploads
 
-Uploaded images are stored on disk under an `uploads/` directory. The `/upload` endpoint returns a relative path like `/files/<filename>` which clients combine with the server URL to load the image.
+Uploaded images are stored on disk under an `uploads/` directory. The `/upload` endpoint returns a relative path like `/files/<filename>` which clients combine with the server URL to load the image. Filenames are sanitized before saving to prevent path traversal.
 
 `docker-compose.yml` mounts a volume for the uploads directory so files persist between restarts.
 

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ Use the checkboxes to track progress.
 - [ ] Scheduled voice events / calendar integration
 - [ ] Server invite links
 - [ ] Theme customization (dark/light)
-- [ ] Sanitize uploaded filenames to prevent path traversal
+- [x] Sanitize uploaded filenames to prevent path traversal
 
 ---
 

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -18,3 +18,4 @@ ed25519-dalek = "1"
 base64 = "0.22"
 axum-extra = { version = "0.9", features = ["typed-header"] }
 serde = { version = "1", features = ["derive"] }
+sanitize-filename = "0.6"

--- a/murmer_server/src/upload.rs
+++ b/murmer_server/src/upload.rs
@@ -3,6 +3,7 @@ use axum::{
     extract::{Multipart, State},
     response::{IntoResponse, Response},
 };
+use sanitize_filename::sanitize;
 use std::sync::Arc;
 use tracing::error;
 
@@ -10,10 +11,13 @@ use crate::AppState;
 
 pub async fn upload(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
     while let Ok(Some(field)) = multipart.next_field().await {
-        let filename = field
+        let mut filename = field
             .file_name()
-            .map(|s| s.to_string())
+            .map(|s| sanitize(s))
             .unwrap_or_else(|| "upload".to_string());
+        if filename.is_empty() {
+            filename = "upload".to_string();
+        }
         if let Ok(data) = field.bytes().await {
             let key = format!("{}-{}", chrono::Utc::now().timestamp_millis(), filename);
             let path = state.upload_dir.join(&key);


### PR DESCRIPTION
## Summary
- sanitize uploaded filenames using `sanitize-filename`
- document filename sanitization in README
- mark TODO item complete

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687eb2761ab883279ece38ac44305ebd