### PR TITLE
Load channel-specific history

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@ Use the checkboxes to track progress.
 - [ ] Direct messages between users
 - [ ] Slash commands for quick actions
 - [ ] Ephemeral messages that auto-delete
-- [ ] Load chat history only for the selected channel
+- [x] Load chat history only for the selected channel
 
 ### 🎤 Voice Features
 

--- a/murmer_client/src/lib/types.ts
+++ b/murmer_client/src/lib/types.ts
@@ -3,6 +3,7 @@ export interface Message {
   user: string;
   text?: string;
   time?: string;
+  channel?: string;
   [key: string]: unknown;
 }
 

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -183,6 +183,7 @@
   function joinChannel(ch: string) {
     if (ch === currentChannel) return;
     currentChannel = ch;
+    chat.clear();
     chat.sendRaw({ type: 'join', channel: ch });
     scrollBottom();
   }

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -136,7 +136,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
 
     let mut authenticated = state.password.is_none();
 
-    db::send_all_history(&state.db, &mut sender).await;
+    db::send_history(&state.db, &mut sender, &channel).await;
     broadcast_voice(&state).await;
     send_all_roles(&state, &mut sender).await;
     send_channels(&state, &mut sender).await;
@@ -233,6 +233,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                     channel = ch.to_string();
                                     chan_tx = get_or_create_channel(&state, &channel).await;
                                     chan_rx = chan_tx.subscribe();
+                                    db::send_history(&state.db, &mut sender, &channel).await;
                                 }
                             }
                             "create-channel" => {


### PR DESCRIPTION
## Summary
- load chat history for the current channel only
- clear chat messages when switching channels
- add channel field to message type
- check off completed todo item

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687eb2a79ee883278bbd00adf148b2f7