### PR TITLE
Implement lazy chat history loading

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -53,6 +53,12 @@ function createChatStore() {
           if (!current || msg.user !== current) {
             notify('New message', `${msg.user}: ${msg.text ?? ''}`);
           }
+        } else if (msg.type === 'history') {
+          const msgs = (msg.messages as Message[]) || [];
+          update((m) => [...msgs, ...m]);
+          if (handlers['history']) {
+            for (const handler of handlers['history']) handler(msg);
+          }
         } else if (msg.type && handlers[msg.type]) {
           for (const handler of handlers[msg.type]) {
             handler(msg);
@@ -84,6 +90,10 @@ function createChatStore() {
     }
   }
 
+  function loadHistory(channel: string, before?: number, limit = 50) {
+    sendRaw({ type: 'load-history', channel, before, limit });
+  }
+
   function disconnect() {
     if (socket) {
       socket.close();
@@ -92,7 +102,7 @@ function createChatStore() {
     set([]); // clear chat history on disconnect
   }
 
-  return { subscribe, connect, send, sendRaw, on, off, disconnect, clear: () => set([]) };
+  return { subscribe, connect, send, sendRaw, loadHistory, on, off, disconnect, clear: () => set([]) };
 }
 
 export const chat = createChatStore();

--- a/murmer_client/src/lib/types.ts
+++ b/murmer_client/src/lib/types.ts
@@ -1,9 +1,11 @@
 export interface Message {
   type: string;
-  user: string;
+  user?: string;
   text?: string;
   time?: string;
   channel?: string;
+  id?: number;
+  messages?: Message[];
   [key: string]: unknown;
 }
 

--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -56,26 +56,58 @@ INSERT INTO channels (name) VALUES ('general') ON CONFLICT DO NOTHING;
 
 use axum::extract::ws::{Message, WebSocket};
 use futures::SinkExt;
+use serde_json::Value;
+use tracing::error;
 
-/// Send all messages from the given channel over the provided WebSocket.
+/// Fetch a slice of messages from the database.
+pub async fn fetch_history(
+    db: &Client,
+    channel: &str,
+    before: Option<i64>,
+    limit: i64,
+) -> Result<Vec<(i64, String)>, tokio_postgres::Error> {
+    let rows = if let Some(id) = before {
+        db.query(
+            "SELECT id, content FROM messages WHERE channel = $1 AND id < $2 ORDER BY id DESC LIMIT $3",
+            &[&channel, &id, &limit],
+        )
+        .await?
+    } else {
+        db.query(
+            "SELECT id, content FROM messages WHERE channel = $1 ORDER BY id DESC LIMIT $2",
+            &[&channel, &limit],
+        )
+        .await?
+    };
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.get::<_, i64>(0), row.get(1)))
+        .collect())
+}
+
+/// Send a slice of messages over the WebSocket as a `history` payload.
 pub async fn send_history(
     db: &Client,
     sender: &mut futures::stream::SplitSink<WebSocket, Message>,
     channel: &str,
+    before: Option<i64>,
+    limit: i64,
 ) {
-    if let Ok(rows) = db
-        .query(
-            "SELECT content FROM messages WHERE channel = $1 ORDER BY id",
-            &[&channel],
-        )
-        .await
-    {
-        for row in rows {
-            let content: String = row.get(0);
-            if sender.send(Message::Text(content.into())).await.is_err() {
-                break;
+    match fetch_history(db, channel, before, limit).await {
+        Ok(rows) => {
+            let mut msgs = Vec::new();
+            for (id, content) in rows.into_iter().rev() {
+                if let Ok(mut val) = serde_json::from_str::<Value>(&content) {
+                    val["id"] = Value::from(id);
+                    msgs.push(val);
+                }
+            }
+            if !msgs.is_empty() {
+                let payload = serde_json::json!({"type": "history", "messages": msgs});
+                let _ = sender.send(Message::Text(payload.to_string().into())).await;
             }
         }
+        Err(e) => error!("db history error: {e}"),
     }
 }
 


### PR DESCRIPTION
## Summary
- fetch chat history in pages from the server
- append message `id` when storing and sending chat messages
- send recent messages and handle history requests via `load-history`
- load older chat messages on scroll in the client

## Testing
- `npm run check`
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_687f631d1e748327ba8203e4ea0eabc8