### PR TITLE
Fix history query

### DIFF
--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -67,9 +67,10 @@ pub async fn fetch_history(
     limit: i64,
 ) -> Result<Vec<(i64, String)>, tokio_postgres::Error> {
     let rows = if let Some(id) = before {
+        let id32 = id as i32;
         db.query(
             "SELECT id, content FROM messages WHERE channel = $1 AND id < $2 ORDER BY id DESC LIMIT $3",
-            &[&channel, &id, &limit],
+            &[&channel, &id32, &limit],
         )
         .await?
     } else {


### PR DESCRIPTION
## Summary
- avoid sending `i64` ids to the `int4` `messages.id` column

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_687f68fc03308327b36760b7f9f0cf90