### PR TITLE
Remove unused send_all_history helper

### DIFF
--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -112,24 +112,6 @@ pub async fn send_history(
     }
 }
 
-/// Send the full message history across all channels.
-pub async fn send_all_history(
-    db: &Client,
-    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
-) {
-    if let Ok(rows) = db
-        .query("SELECT content FROM messages ORDER BY id", &[])
-        .await
-    {
-        for row in rows {
-            let content: String = row.get(0);
-            if sender.send(Message::Text(content.into())).await.is_err() {
-                break;
-            }
-        }
-    }
-}
-
 /// Get the role for a user by public key, if any.
 pub async fn get_role(db: &Client, key: &str) -> Option<String> {
     db.query_opt("SELECT role FROM roles WHERE public_key = $1", &[&key])


### PR DESCRIPTION
## Summary
- clean up `db.rs` by removing the unused `send_all_history` function

## Testing
- `npm run check` in `murmer_client`


------
https://chatgpt.com/codex/tasks/task_e_687f6c7e6d24832790bb4711ff68d321