### PR TITLE
Add user roles to sidebar

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -411,7 +411,18 @@
         {#each $onlineUsers as user}
           <li>
             <span class="status online"></span>
-            <span>{user}</span>
+            <span
+              class="username"
+              style={$roles[user]?.color ? `color: ${$roles[user].color}` : ''}
+              >{user}</span
+            >
+            {#if $roles[user]}
+              <span
+                class="role"
+                style={$roles[user].color ? `color: ${$roles[user].color}` : ''}
+                >{$roles[user].role}</span
+              >
+            {/if}
           </li>
         {/each}
       </ul>
@@ -420,7 +431,18 @@
         {#each $offlineUsers as user}
           <li>
             <span class="status offline"></span>
-            <span class="offline">{user}</span>
+            <span
+              class="username"
+              style={$roles[user]?.color ? `color: ${$roles[user].color}` : ''}
+              >{user}</span
+            >
+            {#if $roles[user]}
+              <span
+                class="role"
+                style={$roles[user].color ? `color: ${$roles[user].color}` : ''}
+                >{$roles[user].role}</span
+              >
+            {/if}
           </li>
         {/each}
       </ul>
@@ -429,7 +451,18 @@
         {#each $voiceUsers as user}
           <li>
             <span class="status voice"></span>
-            <span>{user}</span>
+            <span
+              class="username"
+              style={$roles[user]?.color ? `color: ${$roles[user].color}` : ''}
+              >{user}</span
+            >
+            {#if $roles[user]}
+              <span
+                class="role"
+                style={$roles[user].color ? `color: ${$roles[user].color}` : ''}
+                >{$roles[user].role}</span
+              >
+            {/if}
             {#if user !== $session.user}
               <ConnectionBars strength={strength(user)} />
             {/if}


### PR DESCRIPTION
## Summary
- show user roles next to names in the chat sidebar
- color usernames based on role

## Testing
- `cargo fmt`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687f7484c0a0832785518bf7c06afa7d