### PR TITLE
Add server availability checks

### DIFF
--- a/murmer_client/src/lib/components/StatusDot.svelte
+++ b/murmer_client/src/lib/components/StatusDot.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let online: boolean | null = null;
+  $: color = online === null ? '#6b7280' : online ? '#22c55e' : '#dc2626';
+  $: label = online === null ? 'checking' : online ? 'online' : 'offline';
+</script>
+
+<span class="status" style="background:{color}" aria-label={label} title={label}></span>
+
+<style>
+  .status {
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    display: inline-block;
+  }
+</style>

--- a/murmer_client/src/lib/stores/serverStatus.ts
+++ b/murmer_client/src/lib/stores/serverStatus.ts
@@ -1,0 +1,63 @@
+import { writable, get } from 'svelte/store';
+import { servers } from './servers';
+import { browser } from '$app/environment';
+
+export interface StatusMap {
+  [url: string]: boolean | null;
+}
+
+function toHttp(url: string): string {
+  try {
+    const u = new URL(url);
+    u.protocol = u.protocol.replace('ws', 'http');
+    if (u.pathname.endsWith('/ws')) u.pathname = u.pathname.slice(0, -3);
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+function createStatusStore() {
+  const { subscribe, update, set } = writable<StatusMap>({});
+  let interval: number | null = null;
+
+  async function check(url: string): Promise<boolean> {
+    try {
+      const res = await fetch(toHttp(url), { method: 'HEAD' });
+      return !!res;
+    } catch {
+      return false;
+    }
+  }
+
+  async function checkAll() {
+    const list = get(servers);
+    for (const entry of list) {
+      const ok = await check(entry.url);
+      update((map) => ({ ...map, [entry.url]: ok }));
+    }
+  }
+
+  function start() {
+    if (!browser) return;
+    stop();
+    set({});
+    checkAll();
+    interval = window.setInterval(checkAll, 30000);
+  }
+
+  function stop() {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+  }
+
+  servers.subscribe(() => {
+    if (browser) checkAll();
+  });
+
+  return { subscribe, start, stop };
+}
+
+export const serverStatus = createStatusStore();

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -2,13 +2,20 @@
   import { goto } from '$app/navigation';
   import { servers, selectedServer, type ServerEntry } from '$lib/stores/servers';
   import { session } from '$lib/stores/session';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import SettingsModal from '$lib/components/SettingsModal.svelte';
   import { normalizeServerUrl } from '$lib/utils';
+  import { serverStatus } from '$lib/stores/serverStatus';
+  import StatusDot from '$lib/components/StatusDot.svelte';
 
   onMount(() => {
     if (!get(session).user) goto('/login');
+    serverStatus.start();
+  });
+
+  onDestroy(() => {
+    serverStatus.stop();
   });
 
   let newServer = '';
@@ -71,6 +78,7 @@
     {#each $servers as server}
       <li>
         <button on:click={() => join(server)} title={server.url}>{server.name}</button>
+        <StatusDot online={$serverStatus[server.url]} />
         <button class="del" on:click={() => removeServer(server.url)}>Delete</button>
       </li>
     {/each}


### PR DESCRIPTION
## Summary
- add `serverStatus` store to track server availability
- add `StatusDot` component for server list
- show status indicator next to each server and start/stop checks on mount

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687f7f9dda848327b562e5a0573ea2d9