### PR TITLE
Improve auth flow and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Murmer
 
-Murmer is a **self-hostable** minimal voice and text chat prototype built with Tauri and SvelteKit.
+Murmer is a **self-hostable** minimal voice and text chat prototype.  It consists of
+a Rust WebSocket server and a cross‑platform desktop client built with
+Tauri and SvelteKit.
 
 ## Overview
 * Persistent text chat backed by PostgreSQL

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -141,12 +141,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
 
     let mut authenticated = state.password.is_none();
 
-    db::send_history(&state.db, &mut sender, &channel, None, 50).await;
-    broadcast_voice(&state).await;
-    send_all_roles(&state, &mut sender).await;
-    send_channels(&state, &mut sender).await;
-    send_users(&state, &mut sender).await;
-
     loop {
         tokio::select! {
             Some(result) = receiver.next() => {
@@ -230,6 +224,11 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                                 broadcast_role(&state, u, &info).await;
                                             }
                                         }
+                                        send_all_roles(&state, &mut sender).await;
+                                        send_channels(&state, &mut sender).await;
+                                        send_users(&state, &mut sender).await;
+                                        broadcast_voice(&state).await;
+                                        db::send_history(&state.db, &mut sender, &channel, None, 50).await;
                                     }
                                 } else {
                                     let _ = sender


### PR DESCRIPTION
## Summary
- require successful authentication before sending initial history and server info
- clarify project overview in the README

## Testing
- `npm run check`
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_687f81cf960083278c1b4acbe493a7f2