### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,0 +1,51 @@
+name: Build client on release
+
+on:
+  release:
+    types: [published, prereleased]
+
+jobs:
+  build-client:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install dependencies
+        run: |
+          cd murmer_client
+          npm ci
+
+      - name: Build Tauri app
+        run: |
+          cd murmer_client
+          npm run tauri build
+
+      - name: Locate exe
+        id: locate
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Path "murmer_client/src-tauri/target/release/bundle" -Filter *.exe -Recurse | Select-Object -First 1
+          if (-not $exe) { throw 'exe not found' }
+          "file=$($exe.FullName)" >> $env:GITHUB_OUTPUT
+          "name=$($exe.Name)" >> $env:GITHUB_OUTPUT
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.locate.outputs.file }}
+          asset_name: ${{ steps.locate.outputs.name }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- build the client when a release or pre-release is published
- attach the generated `.exe` to the release

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687fa5bf0f508327a5077cb4b1b53690