### PR TITLE
Fix release upload permissions

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-client:
+    permissions:
+      contents: write
     runs-on: windows-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- ensure `build-client` job can upload assets by granting write access to release

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_687fb6f8e5588327983ec1814d746e89