### PR TITLE
Implement context menu for channel actions

### DIFF
--- a/murmer_client/src/lib/components/ContextMenu.svelte
+++ b/murmer_client/src/lib/components/ContextMenu.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  export let items: { label: string; action: () => void }[] = [];
+  export let x = 0;
+  export let y = 0;
+  export let open = false;
+
+  function close() {
+    open = false;
+  }
+
+  function handleClickOutside(event: MouseEvent) {
+    if (!(event.target as HTMLElement).closest('.menu')) {
+      close();
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('contextmenu', handleClickOutside);
+  });
+  onDestroy(() => {
+    document.removeEventListener('click', handleClickOutside);
+    document.removeEventListener('contextmenu', handleClickOutside);
+  });
+</script>
+
+{#if open}
+  <ul class="menu" style="top:{y}px;left:{x}px">
+    {#each items as item}
+      <li class="entry" on:click={() => { item.action(); close(); }}>{item.label}</li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .menu {
+    position: fixed;
+    background: var(--color-panel);
+    border: 1px solid #4b5563;
+    padding: 0.25rem 0;
+    z-index: 1000;
+  }
+
+  .entry {
+    padding: 0.25rem 1rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .entry:hover {
+    background: #374151;
+  }
+</style>

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -14,6 +14,7 @@
   import ConnectionBars from '$lib/components/ConnectionBars.svelte';
   import SettingsModal from '$lib/components/SettingsModal.svelte';
   import PingDot from '$lib/components/PingDot.svelte';
+  import ContextMenu from '$lib/components/ContextMenu.svelte';
   import { ping } from '$lib/stores/ping';
   import { channels } from '$lib/stores/channels';
   import { loadKeyPair, sign } from '$lib/keypair';
@@ -28,6 +29,9 @@
   let fileInput: HTMLInputElement;
   let messageInput: HTMLTextAreaElement;
   let previewUrl: string | null = null;
+  let menuOpen = false;
+  let menuX = 0;
+  let menuY = 0;
 
   function handleFileChange() {
     const file = fileInput?.files?.[0];
@@ -210,10 +214,16 @@
     goto('/servers');
   }
 
-  function openChannelMenu(event: MouseEvent) {
-    event.preventDefault();
+  function createChannelPrompt() {
     const name = prompt('New channel name');
     if (name) channels.create(name);
+  }
+
+  function openChannelMenu(event: MouseEvent) {
+    event.preventDefault();
+    menuX = event.clientX;
+    menuY = event.clientY;
+    menuOpen = true;
   }
 
   function logout() {
@@ -228,6 +238,13 @@
   function closeSettings() {
     settingsOpen = false;
   }
+
+  $: channelMenuItems = [
+    { label: 'Create Channel', action: createChannelPrompt },
+    inVoice
+      ? { label: 'Leave Voice', action: leaveVoice }
+      : { label: 'Join Voice', action: joinVoice }
+  ];
 
   let messagesContainer: HTMLDivElement;
   async function scrollBottom() {
@@ -473,6 +490,8 @@
       </ul>
   </div>
 </div>
+
+<ContextMenu bind:open={menuOpen} x={menuX} y={menuY} items={channelMenuItems} />
 
 <style>
   .page {


### PR DESCRIPTION
## Summary
- add reusable `ContextMenu` component
- use new context menu in chat page
- allow creating channels or toggling voice chat from the menu

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68809d3c4b008327b8cc08e81753d228