### PR TITLE
Fix a11y issues in ContextMenu

### DIFF
--- a/murmer_client/src/lib/components/ContextMenu.svelte
+++ b/murmer_client/src/lib/components/ContextMenu.svelte
@@ -28,7 +28,18 @@
 {#if open}
   <ul class="menu" style="top:{y}px;left:{x}px">
     {#each items as item}
-      <li class="entry" on:click={() => { item.action(); close(); }}>{item.label}</li>
+      <li>
+        <button
+          type="button"
+          class="entry"
+          on:click={() => {
+            item.action();
+            close();
+          }}
+        >
+          {item.label}
+        </button>
+      </li>
     {/each}
   </ul>
 {/if}
@@ -46,6 +57,12 @@
     padding: 0.25rem 1rem;
     cursor: pointer;
     white-space: nowrap;
+    background: none;
+    border: none;
+    color: inherit;
+    width: 100%;
+    text-align: left;
+    display: block;
   }
   .entry:hover {
     background: #374151;


### PR DESCRIPTION
## Summary
- convert ContextMenu entries to `<button>` elements
- adjust styles for buttons

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68809febf5f48327bf2f55e528e0fc04