### PR TITLE
Add health check endpoint

### DIFF
--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -93,6 +93,7 @@ async fn main() {
     let cors = CorsLayer::permissive();
 
     let app = Router::new()
+        .route("/", get(|| async { "OK" }))
         .route("/ws", get(ws::ws_handler))
         .route("/upload", post(upload::upload))
         .route("/role", post(admin::set_role))


### PR DESCRIPTION
## Summary
- add `/` route to server for HEAD/GET health checks

## Testing
- `cargo fmt`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880a3b0054083279fa32ad99b407387