### PR TITLE
Add HEAD handler for server health

### DIFF
--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -92,8 +92,13 @@ async fn main() {
 
     let cors = CorsLayer::permissive();
 
+    use axum::http::StatusCode;
+
     let app = Router::new()
-        .route("/", get(|| async { "OK" }))
+        .route(
+            "/",
+            get(|| async { "OK" }).head(|| async { StatusCode::OK }),
+        )
         .route("/ws", get(ws::ws_handler))
         .route("/upload", post(upload::upload))
         .route("/role", post(admin::set_role))


### PR DESCRIPTION
## Summary
- return `200 OK` for HEAD requests on `/`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880a594a18483279097b1342e06d6a3