### PR TITLE
Fix context menu closing immediately

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -221,6 +221,7 @@
 
   function openChannelMenu(event: MouseEvent) {
     event.preventDefault();
+    event.stopPropagation();
     menuX = event.clientX;
     menuY = event.clientY;
     menuOpen = true;

--- a/murmer_client/vite.config.ts
+++ b/murmer_client/vite.config.ts
@@ -1,3 +1,4 @@
 import devtoolsJson from 'vite-plugin-devtools-json';
+import { defineConfig } from 'vite';
 
 export default defineConfig({ plugins: [devtoolsJson()] });


### PR DESCRIPTION
## Summary
- keep channel context menu from closing when opened
- include vite `defineConfig` import for type checking

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880a9f3c9e483279e0593db2be000ac