### PR TITLE
Add voice channel support

### DIFF
--- a/murmer_client/src/lib/stores/voice.ts
+++ b/murmer_client/src/lib/stores/voice.ts
@@ -8,8 +8,8 @@ manager.subscribe((list) => peers.set(list));
 
 export const voice = {
   subscribe: peers.subscribe,
-  join: (user: string) => manager.join(user, get(peers)),
-  leave: () => manager.leave(get(peers))
+  join: (user: string, channel: string) => manager.join(user, channel, get(peers)),
+  leave: (channel: string) => manager.leave(channel, get(peers))
 };
 
 export const voiceStats = derived(voice, ($voice) => {

--- a/murmer_client/src/lib/stores/voiceUsers.ts
+++ b/murmer_client/src/lib/stores/voiceUsers.ts
@@ -3,10 +3,11 @@ import { chat } from './chat';
 import type { Message } from '../types';
 
 function createVoiceUserStore() {
-  const { subscribe, set } = writable<string[]>([]);
+  const { subscribe, update } = writable<Record<string, string[]>>({});
   chat.on('voice-users', (msg: Message) => {
-    if (Array.isArray(msg.users)) {
-      set(msg.users as string[]);
+    const ch = (msg as any).channel;
+    if (typeof ch === 'string' && Array.isArray(msg.users)) {
+      update((m) => ({ ...m, [ch]: msg.users as string[] }));
     }
   });
   return { subscribe };

--- a/murmer_client/src/lib/voice/manager.ts
+++ b/murmer_client/src/lib/voice/manager.ts
@@ -19,6 +19,7 @@ export class VoiceManager {
   private statsIntervals: Record<string, number> = {};
   private localStream: MediaStream | null = null;
   private userName: string | null = null;
+  private channel: string | null = null;
   private listeners: Array<(peers: RemotePeer[]) => void> = [];
 
   private joinSound = new Audio('/sounds/user_join_voice_sound.mp3');
@@ -117,12 +118,13 @@ export class VoiceManager {
     };
     pc.onicecandidate = (ev) => {
       if (ev.candidate && this.userName) {
-        chat.sendRaw({
-          type: 'voice-candidate',
-          user: this.userName,
-          target: id,
-          candidate: ev.candidate
-        });
+          chat.sendRaw({
+            type: 'voice-candidate',
+            user: this.userName,
+            target: id,
+            channel: this.channel,
+            candidate: ev.candidate
+          });
       }
     };
     pc.onconnectionstatechange = () => {
@@ -134,14 +136,15 @@ export class VoiceManager {
     if (initiator && this.userName) {
       const offer = await pc.createOffer();
       await pc.setLocalDescription(offer);
-      chat.sendRaw({ type: 'voice-offer', user: this.userName, target: id, sdp: offer });
+      chat.sendRaw({ type: 'voice-offer', user: this.userName, target: id, channel: this.channel, sdp: offer });
     }
     return pc;
   }
 
-  async join(user: string, peersList: RemotePeer[]) {
+  async join(user: string, channel: string, peersList: RemotePeer[]) {
     if (this.userName) return;
     this.userName = user;
+    this.channel = channel;
     chat.on('voice-join', (m) => this.handleJoin(m, peersList));
     chat.on('voice-offer', (m) => this.handleOffer(m, peersList));
     chat.on('voice-answer', (m) => this.handleAnswer(m));
@@ -151,12 +154,12 @@ export class VoiceManager {
     const constraints: MediaStreamConstraints =
       device ? { audio: { deviceId: { exact: device } } } : { audio: true };
     this.localStream = await navigator.mediaDevices.getUserMedia(constraints);
-    chat.sendRaw({ type: 'voice-join', user });
+    chat.sendRaw({ type: 'voice-join', user, channel });
   }
 
-  leave(peersList: RemotePeer[]) {
+  leave(channel: string, peersList: RemotePeer[]) {
     if (!this.userName) return;
-    chat.sendRaw({ type: 'voice-leave', user: this.userName });
+    chat.sendRaw({ type: 'voice-leave', user: this.userName, channel });
     for (const id of Object.keys(this.peers)) {
       this.cleanupPeer(id, peersList);
     }
@@ -170,12 +173,13 @@ export class VoiceManager {
     chat.off('voice-candidate');
     chat.off('voice-leave');
     this.userName = null;
+    this.channel = null;
     peersList.length = 0;
     this.emit([]);
   }
 
   private handleJoin(msg: Message, peersList: RemotePeer[]) {
-    if (!this.userName || msg.user === this.userName) return;
+    if (!this.userName || msg.user === this.userName || msg.channel !== this.channel) return;
     this.createPeer(msg.user as string, true, peersList);
     try {
       this.joinSound.currentTime = 0;
@@ -184,16 +188,16 @@ export class VoiceManager {
   }
 
   private async handleOffer(msg: Message, peersList: RemotePeer[]) {
-    if (!this.userName || msg.target !== this.userName) return;
+    if (!this.userName || msg.target !== this.userName || msg.channel !== this.channel) return;
     const pc = await this.createPeer(msg.user as string, false, peersList);
     await pc.setRemoteDescription(new RTCSessionDescription(msg.sdp as any));
     const answer = await pc.createAnswer();
     await pc.setLocalDescription(answer);
-    chat.sendRaw({ type: 'voice-answer', user: this.userName, target: msg.user, sdp: answer });
+    chat.sendRaw({ type: 'voice-answer', user: this.userName, target: msg.user, channel: this.channel, sdp: answer });
   }
 
   private async handleAnswer(msg: Message) {
-    if (!this.userName || msg.target !== this.userName) return;
+    if (!this.userName || msg.target !== this.userName || msg.channel !== this.channel) return;
     const pc = this.peers[msg.user as string];
     if (pc && !pc.currentRemoteDescription) {
       await pc.setRemoteDescription(new RTCSessionDescription(msg.sdp as any));
@@ -201,7 +205,7 @@ export class VoiceManager {
   }
 
   private async handleCandidate(msg: Message) {
-    if (!this.userName || msg.target !== this.userName) return;
+    if (!this.userName || msg.target !== this.userName || msg.channel !== this.channel) return;
     const pc = this.peers[msg.user as string];
     if (pc) {
       try {
@@ -211,7 +215,7 @@ export class VoiceManager {
   }
 
   private handleLeave(msg: Message, peersList: RemotePeer[]) {
-    if (!this.userName) return;
+    if (!this.userName || msg.channel !== this.channel) return;
     this.cleanupPeer(msg.user as string, peersList);
     try {
       this.leaveSound.currentTime = 0;

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -125,7 +125,7 @@
 
   onDestroy(() => {
     chat.disconnect();
-    voice.leave();
+    voice.leave(currentChannel);
     ping.stop();
     roles.set({});
   });
@@ -197,19 +197,19 @@
 
   function joinVoice() {
     if ($session.user) {
-      voice.join($session.user);
+      voice.join($session.user, currentChannel);
       inVoice = true;
     }
   }
 
   function leaveVoice() {
-    voice.leave();
+    voice.leave(currentChannel);
     inVoice = false;
   }
 
   function leaveServer() {
     chat.disconnect();
-    voice.leave();
+    voice.leave(currentChannel);
     selectedServer.set(null);
     goto('/servers');
   }
@@ -470,7 +470,7 @@
       </ul>
       <h2>Voice</h2>
       <ul>
-        {#each $voiceUsers as user}
+        {#each $voiceUsers[currentChannel] ?? [] as user}
           <li>
             <span class="status voice"></span>
             <span

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -41,7 +41,7 @@ use tracing::info;
 /// - `db`: PostgreSQL client for persisting chat history.
 /// - `users`: set of currently connected chat users.
 /// - `known_users`: set of all users that have ever joined while the server is running.
-/// - `voice_users`: set of users active in voice chat.
+/// - `voice_channels`: map of voice channel names to active users.
 /// - `upload_dir`: directory where uploaded files are stored.
 pub struct AppState {
     pub tx: broadcast::Sender<String>,
@@ -49,7 +49,7 @@ pub struct AppState {
     pub db: Arc<tokio_postgres::Client>,
     pub users: Arc<Mutex<HashSet<String>>>,
     pub known_users: Arc<Mutex<HashSet<String>>>,
-    pub voice_users: Arc<Mutex<HashSet<String>>>,
+    pub voice_channels: Arc<Mutex<HashMap<String, HashSet<String>>>>,
     pub roles: Arc<Mutex<HashMap<String, RoleInfo>>>,
     pub user_keys: Arc<Mutex<HashMap<String, String>>>,
     pub upload_dir: PathBuf,
@@ -82,7 +82,7 @@ async fn main() {
         db: Arc::new(db_client),
         users: Arc::new(Mutex::new(HashSet::new())),
         known_users: Arc::new(Mutex::new(HashSet::new())),
-        voice_users: Arc::new(Mutex::new(HashSet::new())),
+        voice_channels: Arc::new(Mutex::new(HashMap::new())),
         roles: Arc::new(Mutex::new(HashMap::new())),
         user_keys: Arc::new(Mutex::new(HashMap::new())),
         upload_dir: PathBuf::from(upload_dir.clone()),

--- a/murmer_server/src/ws.rs
+++ b/murmer_server/src/ws.rs
@@ -57,13 +57,17 @@ async fn send_users(state: &Arc<AppState>, sender: &mut SplitSink<WebSocket, Mes
     }
 }
 
-/// Broadcast the users currently in the voice channel to all clients.
-async fn broadcast_voice(state: &Arc<AppState>) {
-    let v = state.voice_users.lock().await;
-    let list: Vec<String> = v.iter().cloned().collect();
-    drop(v);
+/// Broadcast the users currently in a voice channel to all clients.
+async fn broadcast_voice(state: &Arc<AppState>, channel: &str) {
+    let vc = state.voice_channels.lock().await;
+    let list: Vec<String> = vc
+        .get(channel)
+        .map(|set| set.iter().cloned().collect())
+        .unwrap_or_default();
+    drop(vc);
     if let Ok(msg) = serde_json::to_string(&serde_json::json!({
         "type": "voice-users",
+        "channel": channel,
         "users": list,
     })) {
         let _ = state.tx.send(msg);
@@ -110,6 +114,22 @@ async fn send_channels(state: &Arc<AppState>, sender: &mut SplitSink<WebSocket, 
     }
 }
 
+/// Send all voice channel member lists to a client.
+async fn send_all_voice(state: &Arc<AppState>, sender: &mut SplitSink<WebSocket, Message>) {
+    let map = state.voice_channels.lock().await.clone();
+    for (chan, users) in map {
+        if let Ok(msg) = serde_json::to_string(&serde_json::json!({
+            "type": "voice-users",
+            "channel": chan,
+            "users": users.into_iter().collect::<Vec<_>>(),
+        })) {
+            if sender.send(Message::Text(msg)).await.is_err() {
+                break;
+            }
+        }
+    }
+}
+
 /// Broadcast to all clients that a new channel was created.
 async fn broadcast_new_channel(state: &Arc<AppState>, name: &str) {
     if let Ok(msg) = serde_json::to_string(&serde_json::json!({
@@ -138,6 +158,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
     let mut chan_tx = get_or_create_channel(&state, &channel).await;
     let mut chan_rx = chan_tx.subscribe();
     let mut user_name: Option<String> = None;
+    let mut voice_channel: Option<String> = None;
 
     let mut authenticated = state.password.is_none();
 
@@ -227,7 +248,7 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                         send_all_roles(&state, &mut sender).await;
                                         send_channels(&state, &mut sender).await;
                                         send_users(&state, &mut sender).await;
-                                        broadcast_voice(&state).await;
+                                        send_all_voice(&state, &mut sender).await;
                                         db::send_history(&state.db, &mut sender, &channel, None, 50).await;
                                     }
                                 } else {
@@ -288,19 +309,37 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
                                     .await;
                             }
                             "voice-join" => {
-                                if let Some(u) = v.get("user").and_then(|u| u.as_str()) {
-                                    let mut voice = state.voice_users.lock().await;
-                                    voice.insert(u.to_string());
+                                if let (Some(u), Some(ch)) = (
+                                    v.get("user").and_then(|u| u.as_str()),
+                                    v.get("channel").and_then(|c| c.as_str()),
+                                ) {
+                                    let mut map = state.voice_channels.lock().await;
+                                    for users in map.values_mut() {
+                                        users.remove(u);
+                                    }
+                                    map.entry(ch.to_string()).or_default().insert(u.to_string());
+                                    voice_channel = Some(ch.to_string());
                                 }
-                                broadcast_voice(&state).await;
+                                if let Some(ch) = v.get("channel").and_then(|c| c.as_str()) {
+                                    broadcast_voice(&state, ch).await;
+                                }
                                 let _ = state.tx.send(text.to_string());
                             }
                             "voice-leave" => {
-                                if let Some(u) = v.get("user").and_then(|u| u.as_str()) {
-                                    let mut voice = state.voice_users.lock().await;
-                                    voice.remove(u);
+                                if let (Some(u), Some(ch)) = (
+                                    v.get("user").and_then(|u| u.as_str()),
+                                    v.get("channel").and_then(|c| c.as_str()),
+                                ) {
+                                    let mut map = state.voice_channels.lock().await;
+                                    if let Some(set) = map.get_mut(ch) {
+                                        set.remove(u);
+                                    }
+                                    drop(map);
+                                    broadcast_voice(&state, ch).await;
+                                    if voice_channel.as_deref() == Some(ch) {
+                                        voice_channel = None;
+                                    }
                                 }
-                                broadcast_voice(&state).await;
                                 let _ = state.tx.send(text.to_string());
                             }
                             "voice-offer" | "voice-answer" | "voice-candidate" => {
@@ -341,12 +380,17 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
         users.remove(&name);
         drop(users);
         broadcast_users(&state).await;
-        let mut voice = state.voice_users.lock().await;
-        if voice.remove(&name) {
-            drop(voice);
-            broadcast_voice(&state).await;
-        } else {
-            drop(voice);
+        let mut map = state.voice_channels.lock().await;
+        let mut ch_to_broadcast = None;
+        for (ch, users) in map.iter_mut() {
+            if users.remove(&name) {
+                ch_to_broadcast = Some(ch.clone());
+                break;
+            }
+        }
+        drop(map);
+        if let Some(ch) = ch_to_broadcast {
+            broadcast_voice(&state, &ch).await;
         }
         // Keep role and key mappings so clients can display roles
         // even when the user is offline.


### PR DESCRIPTION
## Summary
- add `voice_channels` map on the server
- broadcast voice membership per channel
- send all voice channel info on presence
- track voice channel membership on join/leave/disconnect
- add channel parameter to client voice manager and store
- list voice users per channel

## Testing
- `cargo fmt`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880b17122a08327b7e099881f3214c6