### PR TITLE
Add context menu option for voice channels

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -219,6 +219,20 @@
     if (name) channels.create(name);
   }
 
+  function createVoiceChannelPrompt() {
+    const name = prompt('New voice channel name');
+    if (!name) return;
+    channels.create(name);
+    if ($session.user) {
+      currentChannel = name;
+      chat.clear();
+      chat.sendRaw({ type: 'join', channel: name });
+      voice.join($session.user, name);
+      inVoice = true;
+      scrollBottom();
+    }
+  }
+
   function openChannelMenu(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
@@ -242,6 +256,7 @@
 
   $: channelMenuItems = [
     { label: 'Create Channel', action: createChannelPrompt },
+    { label: 'Create Voice Channel', action: createVoiceChannelPrompt },
     inVoice
       ? { label: 'Leave Voice', action: leaveVoice }
       : { label: 'Join Voice', action: joinVoice }


### PR DESCRIPTION
## Summary
- enhance channel context menu with "Create Voice Channel"
- auto-join the created channel and voice chat

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880b5f6822c8327aee9b2119459750e