### PR TITLE
Fix duplicate chat history on initial connect

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -117,7 +117,10 @@
           password: entry?.password
         });
       }
-      chat.sendRaw({ type: 'join', channel: currentChannel });
+      // Presence response already loads history for the default channel,
+      // so avoid sending an extra join message which would duplicate chat
+      // history on initial connect. Joining is still handled when the
+      // user switches channels.
       ping.start();
       await scrollBottom();
     });


### PR DESCRIPTION
## Summary
- avoid sending a redundant `join` message when the chat page first mounts

Chat history was being loaded twice when initially connecting to a server. The
server already sends history for the default channel in response to the presence
message, so sending an additional `join` caused duplicates. Removing the initial
`join` avoids this duplication while still allowing channel switches to work as
before.

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880b91549008327972c37536a36aa3f