### PR TITLE
Update channel context menu

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -275,11 +275,9 @@
   }
 
   $: channelMenuItems = [
-    { label: 'Create Channel', action: createChannelPrompt },
+    { label: 'Create Text Channel', action: createChannelPrompt },
     { label: 'Create Voice Channel', action: createVoiceChannelPrompt },
-    inVoice
-      ? { label: 'Leave Voice', action: leaveVoice }
-      : { label: 'Join Voice', action: joinVoice }
+    ...(inVoice ? [{ label: 'Leave Voice', action: leaveVoice }] : [])
   ];
 
   let messagesContainer: HTMLDivElement;


### PR DESCRIPTION
## Summary
- rename "Create Channel" menu item to "Create Text Channel"
- remove "Join Voice" option from channel context menu

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880c17663d883278c6ea8d3ced39972