### PR TITLE
Remove leave voice item

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -280,8 +280,7 @@
 
   $: channelMenuItems = [
     { label: 'Create Text Channel', action: createChannelPrompt },
-    { label: 'Create Voice Channel', action: createVoiceChannelPrompt },
-    ...(inVoice ? [{ label: 'Leave Voice', action: leaveVoice }] : [])
+    { label: 'Create Voice Channel', action: createVoiceChannelPrompt }
   ];
 
   let messagesContainer: HTMLDivElement;


### PR DESCRIPTION
## Summary
- remove "Leave Voice" from the channel context menu

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880c44025b88327bc2aa7cd28c8bc5c