### PR TITLE
Improve voice channel participant display

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -351,9 +351,35 @@
       {/each}
       <h3 class="section">Voice Channels</h3>
       {#each $voiceChannels as ch}
-        <button on:click={() => joinVoiceChannel(ch)}>
-          <span class="chan-icon">🔊</span> {ch}
-        </button>
+        <div class="voice-group">
+          <button on:click={() => joinVoiceChannel(ch)}>
+            <span class="chan-icon">🔊</span> {ch}
+          </button>
+          {#if $voiceUsers[ch]?.length}
+            <ul class="voice-user-list">
+              {#each $voiceUsers[ch] as user}
+                <li>
+                  <span class="status voice"></span>
+                  <span
+                    class="username"
+                    style={$roles[user]?.color ? `color: ${$roles[user].color}` : ''}
+                    >{user}</span
+                  >
+                  {#if $roles[user]}
+                    <span
+                      class="role"
+                      style={$roles[user].color ? `color: ${$roles[user].color}` : ''}
+                      >{$roles[user].role}</span
+                    >
+                  {/if}
+                  <ConnectionBars
+                    strength={user === $session.user ? serverStrength : ($voiceStats[user]?.strength ?? 0)}
+                  />
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
       {/each}
     </div>
     <div class="chat">
@@ -512,27 +538,6 @@
           </li>
         {/each}
       </ul>
-      <h2>Voice</h2>
-      <ul>
-        {#each $voiceUsers[currentVoiceChannel ?? ''] ?? [] as user}
-          <li>
-            <span class="status voice"></span>
-            <span
-              class="username"
-              style={$roles[user]?.color ? `color: ${$roles[user].color}` : ''}
-              >{user}</span
-            >
-            {#if $roles[user]}
-              <span
-                class="role"
-                style={$roles[user].color ? `color: ${$roles[user].color}` : ''}
-                >{$roles[user].role}</span
-              >
-            {/if}
-            <ConnectionBars strength={user === $session.user ? serverStrength : ($voiceStats[user]?.strength ?? 0)} />
-          </li>
-        {/each}
-      </ul>
   </div>
 </div>
 
@@ -581,6 +586,25 @@
 
   .channels button.active {
     background: var(--color-accent);
+  }
+
+  .voice-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.25rem;
+  }
+
+  .voice-user-list {
+    list-style: none;
+    margin: 0.25rem 0 0 1rem;
+    padding: 0;
+  }
+
+  .voice-user-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-bottom: 0.25rem;
   }
 
   .chat {


### PR DESCRIPTION
## Summary
- show users for each voice channel under the channel name
- remove voice user list from sidebar

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880c4986cd48327a933cc506ed8fc72