### PR TITLE
Add channel deletion

### DIFF
--- a/murmer_client/src/lib/stores/channels.ts
+++ b/murmer_client/src/lib/stores/channels.ts
@@ -19,11 +19,22 @@ function createChannelStore() {
     }
   });
 
+  chat.on('channel-remove', (msg: Message) => {
+    const name = (msg as any).channel;
+    if (typeof name === 'string') {
+      update((chs) => chs.filter((c) => c !== name));
+    }
+  });
+
   function create(name: string) {
     chat.sendRaw({ type: 'create-channel', name });
   }
 
-  return { subscribe, set, create };
+  function remove(name: string) {
+    chat.sendRaw({ type: 'delete-channel', name });
+  }
+
+  return { subscribe, set, create, remove };
 }
 
 export const channels = createChannelStore();

--- a/murmer_client/src/lib/stores/voiceChannels.ts
+++ b/murmer_client/src/lib/stores/voiceChannels.ts
@@ -19,11 +19,22 @@ function createVoiceChannelStore() {
     }
   });
 
+  chat.on('voice-channel-remove', (msg: Message) => {
+    const name = (msg as any).channel;
+    if (typeof name === 'string') {
+      update((chs) => chs.filter((c) => c !== name));
+    }
+  });
+
   function create(name: string) {
     chat.sendRaw({ type: 'create-voice-channel', name });
   }
 
-  return { subscribe, set, create };
+  function remove(name: string) {
+    chat.sendRaw({ type: 'delete-voice-channel', name });
+  }
+
+  return { subscribe, set, create, remove };
 }
 
 export const voiceChannels = createVoiceChannelStore();

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -257,11 +257,19 @@
     }
   }
 
-  function openChannelMenu(event: MouseEvent) {
+  let menuChannel: string | null = null;
+  let menuVoiceChannel: string | null = null;
+  function openChannelMenu(event: MouseEvent, channel?: string, voice?: boolean) {
     event.preventDefault();
     event.stopPropagation();
     menuX = event.clientX;
     menuY = event.clientY;
+    menuChannel = null;
+    menuVoiceChannel = null;
+    if (channel) {
+      if (voice) menuVoiceChannel = channel;
+      else menuChannel = channel;
+    }
     menuOpen = true;
   }
 
@@ -280,7 +288,9 @@
 
   $: channelMenuItems = [
     { label: 'Create Text Channel', action: createChannelPrompt },
-    { label: 'Create Voice Channel', action: createVoiceChannelPrompt }
+    { label: 'Create Voice Channel', action: createVoiceChannelPrompt },
+    ...(menuChannel ? [{ label: 'Delete Channel', action: () => channels.remove(menuChannel!) }] : []),
+    ...(menuVoiceChannel ? [{ label: 'Delete Voice Channel', action: () => voiceChannels.remove(menuVoiceChannel!) }] : [])
   ];
 
   let messagesContainer: HTMLDivElement;
@@ -344,6 +354,7 @@
         <button
           class:active={ch === currentChatChannel}
           on:click={() => joinChannel(ch)}
+          on:contextmenu={(e) => openChannelMenu(e, ch)}
         >
           <span class="chan-icon">#</span> {ch}
         </button>
@@ -351,7 +362,7 @@
       <h3 class="section">Voice Channels</h3>
       {#each $voiceChannels as ch}
         <div class="voice-group">
-          <button on:click={() => joinVoiceChannel(ch)}>
+          <button on:click={() => joinVoiceChannel(ch)} on:contextmenu={(e) => openChannelMenu(e, ch, true)}>
             <span class="chan-icon">🔊</span> {ch}
           </button>
           {#if $voiceUsers[ch]?.length}

--- a/murmer_server/src/db.rs
+++ b/murmer_server/src/db.rs
@@ -166,3 +166,10 @@ pub async fn add_channel(db: &Client, name: &str) -> Result<(), tokio_postgres::
     .await
     .map(|_| ())
 }
+
+/// Delete an existing channel.
+pub async fn remove_channel(db: &Client, name: &str) -> Result<(), tokio_postgres::Error> {
+    db.execute("DELETE FROM channels WHERE name = $1", &[&name])
+        .await
+        .map(|_| ())
+}


### PR DESCRIPTION
## Summary
- allow removing text and voice channels
- handle delete messages in the server
- update context menu with delete options

## Testing
- `npm run check`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6880c6d4d7888327aa3a814010debe5b