### PR TITLE
Add resizable sidebars

### DIFF
--- a/murmer_client/src/lib/stores/layout.ts
+++ b/murmer_client/src/lib/stores/layout.ts
@@ -1,0 +1,23 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const LEFT_KEY = 'murmer_left_width';
+const RIGHT_KEY = 'murmer_right_width';
+
+function load(key: string, def: number): number {
+  if (!browser) return def;
+  const raw = localStorage.getItem(key);
+  const val = raw ? parseInt(raw) : NaN;
+  return isNaN(val) ? def : val;
+}
+
+function persist(key: string, val: number) {
+  if (browser) localStorage.setItem(key, String(val));
+}
+
+export const leftSidebarWidth = writable<number>(load(LEFT_KEY, 140));
+export const rightSidebarWidth = writable<number>(load(RIGHT_KEY, 200));
+
+leftSidebarWidth.subscribe((v) => persist(LEFT_KEY, v));
+rightSidebarWidth.subscribe((v) => persist(RIGHT_KEY, v));
+


### PR DESCRIPTION
## Summary
- allow resizing chat sidebars
- store sidebar widths in localStorage

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880c72d27888327ad4e08b666ea91c3