### PR TITLE
Fix Svelte accessibility warnings

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -434,7 +434,7 @@
         </div>
       {/each}
     </div>
-    <div class="resizer" on:mousedown={startLeftResize}></div>
+    <button type="button" class="resizer" on:mousedown={startLeftResize} aria-label="Resize channel list"></button>
     <div class="chat">
       <div class="header">
         <h1>{currentChatChannel}</h1>
@@ -549,7 +549,7 @@
         <audio autoplay use:stream={peer.stream}></audio>
       {/each}
     </div>
-    <div class="resizer" on:mousedown={startRightResize}></div>
+    <button type="button" class="resizer" on:mousedown={startRightResize} aria-label="Resize user list"></button>
     <div class="sidebar" style="width: {$rightSidebarWidth}px">
       <h2>Users</h2>
       <h3>Online</h3>

--- a/murmer_client/src/routes/login/+page.svelte
+++ b/murmer_client/src/routes/login/+page.svelte
@@ -20,7 +20,7 @@
 
 <form class="login-container" on:submit|preventDefault={login}>
   <h1>Login</h1>
-  <input bind:value={username} placeholder="Username" autofocus />
+  <input bind:value={username} placeholder="Username" />
   <button type="submit">Login</button>
 </form>
 

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -69,7 +69,7 @@
   </div>
   <SettingsModal open={settingsOpen} close={closeSettings} />
   <form class="add" on:submit|preventDefault={add}>
-    <input bind:value={newName} placeholder="Server name" autofocus />
+    <input bind:value={newName} placeholder="Server name" />
     <input bind:value={newServer} placeholder="host:port or ws://url" />
     <input type="password" bind:value={newPassword} placeholder="Password (optional)" />
     <button type="submit">Add</button>


### PR DESCRIPTION
## Summary
- remove autofocus attributes in login and server pages
- convert resizer divs to buttons so they have proper roles

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880cd09149c832798469e67b351c18b