### PR TITLE
Tweak sidebar resizer style

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -643,10 +643,11 @@
   }
 
   .resizer {
-    width: 4px;
+    width: 2px;
     cursor: col-resize;
     flex-shrink: 0;
     background: var(--color-panel);
+    transition: background 0.2s;
   }
   .resizer:hover {
     background: var(--color-accent-alt);


### PR DESCRIPTION
## Summary
- narrow the sidebar resizer to 2px so it blends in better
- add a hover transition effect

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880d0bbbaf48327a387498a77d54e7b