### PR TITLE
Make sidebar resizer transparent

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -646,7 +646,7 @@
     width: 2px;
     cursor: col-resize;
     flex-shrink: 0;
-    background: var(--color-panel);
+    background: transparent;
     transition: background 0.2s;
   }
   .resizer:hover {


### PR DESCRIPTION
## Summary
- style tweak to keep the resize handle for the sidebars basically invisible

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6880d2649144832783c774004c88b661