### PR TITLE
Make sidebar resizers plain separators

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -434,7 +434,8 @@
         </div>
       {/each}
     </div>
-    <button type="button" class="resizer" on:mousedown={startLeftResize} aria-label="Resize channel list"></button>
+    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <div class="resizer" role="separator" aria-label="Resize channel list" on:mousedown={startLeftResize}></div>
     <div class="chat">
       <div class="header">
         <h1>{currentChatChannel}</h1>
@@ -549,7 +550,8 @@
         <audio autoplay use:stream={peer.stream}></audio>
       {/each}
     </div>
-    <button type="button" class="resizer" on:mousedown={startRightResize} aria-label="Resize user list"></button>
+    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+    <div class="resizer" role="separator" aria-label="Resize user list" on:mousedown={startRightResize}></div>
     <div class="sidebar" style="width: {$rightSidebarWidth}px">
       <h2>Users</h2>
       <h3>Online</h3>


### PR DESCRIPTION
## Summary
- use `<div role="separator">` for chat sidebar resize handles
- silence Svelte a11y warnings for the mouse handlers

## Testing
- `npm run check` in `murmer_client`
- `cargo check` in `murmer_server`


------
https://chatgpt.com/codex/tasks/task_e_6880ebc288f4832781efdcaf921cf6cc