### PR TITLE
Add Markdown support for text messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Tauri and SvelteKit.
 * Experimental voice chat using WebRTC
 * User roles with customizable colors
 * Image uploads stored on the server
+* Markdown formatting in text chat
 * Cross-platform client powered by Tauri
 
 ## Prerequisites

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Use the checkboxes to track progress.
 
 ### 🗨️ Chat Features
 
-- [ ] Support Markdown formatting in text chat
+- [x] Support Markdown formatting in text chat
 - [ ] Enable deleting messages
 - [ ] Support editing messages
 - [ ] Add reactions with emojis

--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -13,6 +13,8 @@
         "@tauri-apps/plugin-notification": "^2.3.0",
         "@tauri-apps/plugin-opener": "^2.4.0",
         "@tauri-apps/plugin-window-state": "^2.4.0",
+        "dompurify": "^3.2.6",
+        "marked": "^16.1.1",
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
@@ -1180,6 +1182,13 @@
         "undici-types": "~7.8.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1283,6 +1292,15 @@
       "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.8",
@@ -1408,6 +1426,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.1.tgz",
+      "integrity": "sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mri": {

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -17,6 +17,8 @@
     "@tauri-apps/plugin-notification": "^2.3.0",
     "@tauri-apps/plugin-opener": "^2.4.0",
     "@tauri-apps/plugin-window-state": "^2.4.0",
+    "dompurify": "^3.2.6",
+    "marked": "^16.1.1",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {

--- a/murmer_client/src/lib/markdown.ts
+++ b/murmer_client/src/lib/markdown.ts
@@ -1,0 +1,7 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+export function renderMarkdown(text: string): string {
+  const html = marked.parse(text) as string;
+  return DOMPurify.sanitize(html);
+}

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy, afterUpdate, tick } from 'svelte';
-  import { chat } from '$lib/stores/chat';
-  import { roles } from '$lib/stores/roles';
+import { chat } from '$lib/stores/chat';
+import { roles } from '$lib/stores/roles';
   import { session } from '$lib/stores/session';
   import { voice, voiceStats } from '$lib/stores/voice';
   import { selectedServer, servers } from '$lib/stores/servers';
@@ -19,7 +19,8 @@
   import { channels } from '$lib/stores/channels';
   import { voiceChannels } from '$lib/stores/voiceChannels';
   import { leftSidebarWidth, rightSidebarWidth } from '$lib/stores/layout';
-  import { loadKeyPair, sign } from '$lib/keypair';
+import { loadKeyPair, sign } from '$lib/keypair';
+import { renderMarkdown } from '$lib/markdown';
   function pingToStrength(ms: number): number {
     return ms === 0 ? 5 : ms < 50 ? 5 : ms < 100 ? 4 : ms < 200 ? 3 : ms < 400 ? 2 : 1;
   }
@@ -65,9 +66,6 @@
     chat.sendRaw({ type: 'join', channel: currentChatChannel });
   }
 
-  function isCode(text: string): boolean {
-    return /^```[\s\S]*```$/.test(text.trim());
-  }
 
   function stream(node: HTMLAudioElement, media: MediaStream) {
     node.srcObject = media;
@@ -460,11 +458,7 @@
             {/if}
             <span class="content">
               {#if msg.text}
-                {#if isCode(msg.text)}
-                  <pre><code>{msg.text.trim().slice(3, -3)}</code></pre>
-                {:else}
-                  {msg.text}
-                {/if}
+                {@html renderMarkdown(msg.text)}
               {/if}
               {#if msg.image}
                 <img src={msg.image as string} alt="" />
@@ -781,6 +775,13 @@
   .content {
     white-space: pre-wrap;
     overflow-wrap: anywhere;
+  }
+
+  .content pre {
+    background: #1e1e2e;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    overflow-x: auto;
   }
 
   .content img {


### PR DESCRIPTION
## Summary
- parse text messages as Markdown so users can apply basic formatting
- add `dompurify` and `marked` dependencies
- expose `renderMarkdown` helper
- document Markdown formatting support in README and mark TODO item as complete

## Testing
- `npm run check`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6880eb7bc4e48327a2cebde71fe58955