### PR TITLE
Fix markdown spacing in messages

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -779,11 +779,16 @@ import { renderMarkdown } from '$lib/markdown';
     overflow-wrap: anywhere;
   }
 
-  .content pre {
+  :global(.content p) {
+    margin: 0;
+  }
+
+  :global(.content pre) {
     background: #1e1e2e;
     padding: 0.25rem 0.5rem;
     border-radius: 4px;
     overflow-x: auto;
+    margin: 0;
   }
 
   .content img {


### PR DESCRIPTION
## Summary
- shrink extra space around message text blocks

## Testing
- `npm run check`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6880f755adf483278a82023061372493