### PR TITLE
Bump version to 2025.7.24-alpha.2

### DIFF
--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmer",
-  "version": "2025.7.24-alpha.1",
+  "version": "2025.7.24-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmer",
-      "version": "2025.7.24-alpha.1",
+      "version": "2025.7.24-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.7.0",

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmer",
-  "version": "2025.7.24-alpha.1",
+  "version": "2025.7.24-alpha.2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/murmer_client/src-tauri/Cargo.lock
+++ b/murmer_client/src-tauri/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_client"
-version = "2025.7.24-alpha.1"
+version = "2025.7.24-alpha.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/murmer_client/src-tauri/Cargo.toml
+++ b/murmer_client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_client"
-version = "2025.7.24-alpha.1"
+version = "2025.7.24-alpha.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
         "productName": "Murmer",
-        "version": "2025.7.24-alpha.1",
+        "version": "2025.7.24-alpha.2",
         "identifier": "com.murmer.app",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_server"
-version = "2025.7.23-alpha.2"
+version = "2025.7.24-alpha.2"
 dependencies = [
  "axum",
  "axum-extra",

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_server"
-version = "2025.7.23-alpha.2"
+version = "2025.7.24-alpha.2"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- bump client version
- bump server version

## Testing
- `npm run check` *(fails: svelte-check found 4 errors)*
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68829b53866083279f1aca62d86f2cdb