### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,7 @@ Use the checkboxes to track progress.
 - [ ] Real-time collaborative code editing
 - [ ] Scheduled voice events / calendar integration
 - [ ] Server invite links
-- [ ] Theme customization (dark/light)
+- [x] Theme customization (dark/light)
 - [x] Sanitize uploaded filenames to prevent path traversal
 - [ ] Translation services for international teams
 

--- a/murmer_client/src/lib/stores/theme.ts
+++ b/murmer_client/src/lib/stores/theme.ts
@@ -1,0 +1,43 @@
+import { writable, get } from 'svelte/store';
+
+export type Theme = 'dark' | 'light';
+
+const STORAGE_KEY = 'murmer-theme';
+
+function applyTheme(value: Theme) {
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset.theme = value;
+  }
+}
+
+function createThemeStore() {
+  const store = writable<Theme>('dark');
+
+  return {
+    subscribe: store.subscribe,
+    set: (value: Theme) => {
+      store.set(value);
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, value);
+      }
+      applyTheme(value);
+    },
+    toggle: () => {
+      const nextValue: Theme = get(store) === 'dark' ? 'light' : 'dark';
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, nextValue);
+      }
+      store.set(nextValue);
+      applyTheme(nextValue);
+    },
+    init: () => {
+      if (typeof window === 'undefined') return;
+      const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+      const initial: Theme = stored ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      store.set(initial);
+      applyTheme(initial);
+    }
+  };
+}
+
+export const theme = createThemeStore();

--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { APP_VERSION } from '$lib/version';
+  import { theme } from '$lib/stores/theme';
+
+  onMount(() => {
+    theme.init();
+  });
 </script>
 
 <svelte:head>
@@ -31,6 +37,32 @@
     --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4);
     --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  :global(html[data-theme='light']) {
+    --color-bg: #f8fafc;
+    --color-bg-elevated: #ffffff;
+    --color-panel: #ffffff;
+    --color-panel-elevated: #f1f5f9;
+    --color-border: #cbd5f5;
+    --color-border-subtle: #e2e8f0;
+    --color-accent: #4f46e5;
+    --color-accent-alt: #2563eb;
+    --color-accent-hover: #4338ca;
+    --color-text: #0f172a;
+    --color-text-muted: #475569;
+    --color-text-subtle: #64748b;
+    --color-success: #16a34a;
+    --color-warning: #d97706;
+    --color-error: #dc2626;
+    --color-overlay: rgba(15, 23, 42, 0.35);
+    --shadow-sm: 0 1px 2px 0 rgba(15, 23, 42, 0.08);
+    --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.1);
+    --shadow-lg: 0 10px 15px -3px rgba(15, 23, 42, 0.12);
     --radius-sm: 6px;
     --radius-md: 8px;
     --radius-lg: 12px;

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy, afterUpdate, tick } from 'svelte';
-import { chat } from '$lib/stores/chat';
-import { roles } from '$lib/stores/roles';
+  import { chat } from '$lib/stores/chat';
+  import { roles } from '$lib/stores/roles';
   import { session } from '$lib/stores/session';
   import { voice, voiceStats } from '$lib/stores/voice';
   import { selectedServer, servers } from '$lib/stores/servers';
@@ -21,9 +21,10 @@ import { roles } from '$lib/stores/roles';
   import { voiceChannels } from '$lib/stores/voiceChannels';
   import { leftSidebarWidth, rightSidebarWidth, focusMode } from '$lib/stores/layout';
   import { channelTopics } from '$lib/stores/channelTopics';
-import { loadKeyPair, sign } from '$lib/keypair';
-import { renderMarkdown } from '$lib/markdown';
-import type { Message } from '$lib/types';
+  import { theme } from '$lib/stores/theme';
+  import { loadKeyPair, sign } from '$lib/keypair';
+  import { renderMarkdown } from '$lib/markdown';
+  import type { Message } from '$lib/types';
   function pingToStrength(ms: number): number {
     return ms === 0 ? 5 : ms < 50 ? 5 : ms < 100 ? 4 : ms < 200 ? 3 : ms < 400 ? 2 : 1;
   }
@@ -682,6 +683,15 @@ import type { Message } from '$lib/types';
             <PingDot ping={$ping} />
             <ConnectionBars strength={serverStrength} />
           </div>
+          <button
+            class="action-button"
+            on:click={() => theme.toggle()}
+            title={$theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            aria-label={$theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            aria-pressed={$theme === 'light'}
+          >
+            {$theme === 'dark' ? '🌞' : '🌙'}
+          </button>
           <button class="action-button" on:click={editTopic} title="Edit channel topic">📝</button>
           <button
             class="action-button focus-toggle"


### PR DESCRIPTION
## Summary
- add a persisted theme store and initialize it during layout mount
- expose light color variables and a chat header toggle to switch themes
- mark the theme customization feature as completed in the TODO list

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d967fdc09c83278265e41080930478