### PR TITLE
Add server invite link feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -73,7 +73,7 @@ Use the checkboxes to track progress.
 - [ ] Pomodoro timer integration for study groups
 - [ ] Real-time collaborative code editing
 - [ ] Scheduled voice events / calendar integration
-- [ ] Server invite links
+- [x] Server invite links
 - [x] Theme customization (dark/light)
 - [x] Sanitize uploaded filenames to prevent path traversal
 - [ ] Translation services for international teams

--- a/murmer_client/src/lib/invite.ts
+++ b/murmer_client/src/lib/invite.ts
@@ -1,0 +1,62 @@
+import { normalizeServerUrl } from '$lib/utils';
+import type { ServerEntry } from '$lib/stores/servers';
+
+export interface InviteData {
+  url: string;
+  name?: string;
+  password?: string;
+}
+
+/**
+ * Generate a murmer:// invite link for a server entry.
+ *
+ * The link encodes the server URL, display name and optional password
+ * so that other users can add the server without re-entering details.
+ */
+export function createInviteLink(server: ServerEntry): string {
+  const params = new URLSearchParams({ url: server.url });
+  if (server.name && server.name !== server.url) {
+    params.set('name', server.name);
+  }
+  if (server.password) {
+    params.set('password', server.password);
+  }
+  return `murmer://invite?${params.toString()}`;
+}
+
+/**
+ * Parse a murmer:// invite link into its constituent server details.
+ */
+export function parseInviteLink(link: string): InviteData | null {
+  try {
+    const trimmed = link.trim();
+    if (!trimmed) return null;
+
+    const url = new URL(trimmed);
+    if (url.protocol !== 'murmer:') return null;
+
+    const action = url.hostname || url.pathname.replace(/^\//, '');
+    if (action !== 'invite') return null;
+
+    const serverUrl = url.searchParams.get('url');
+    if (!serverUrl) return null;
+
+    const data: InviteData = {
+      url: normalizeServerUrl(serverUrl)
+    };
+
+    const name = url.searchParams.get('name')?.trim();
+    if (name) data.name = name;
+
+    const password = url.searchParams.get('password');
+    if (password) data.password = password;
+
+    return data;
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.error('Failed to parse invite link', err);
+    }
+    return null;
+  }
+}
+

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -104,7 +104,7 @@
     let analyser: AnalyserNode | null = null;
     let sourceNode: MediaStreamAudioSourceNode | null = null;
     let frameId: number | null = null;
-    let buffer: Uint8Array | null = null;
+    let buffer: Uint8Array<ArrayBuffer> | null = null;
 
     const updateVolume = () => {
       if ($outputMuted) {
@@ -183,7 +183,8 @@
         sourceNode = audioContext.createMediaStreamSource(stream);
         analyser = audioContext.createAnalyser();
         analyser.fftSize = 512;
-        buffer = new Uint8Array(analyser.fftSize);
+        const arrayBuffer = new ArrayBuffer(analyser.fftSize);
+        buffer = new Uint8Array<ArrayBuffer>(arrayBuffer);
         sourceNode.connect(analyser);
 
         const update = () => {

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -8,6 +8,7 @@
   import { normalizeServerUrl } from '$lib/utils';
   import { serverStatus } from '$lib/stores/serverStatus';
   import StatusDot from '$lib/components/StatusDot.svelte';
+  import { createInviteLink, parseInviteLink } from '$lib/invite';
 
   onMount(() => {
     if (!get(session).user) goto('/login');
@@ -16,23 +17,64 @@
 
   onDestroy(() => {
     serverStatus.stop();
+    clearCopyTimeout();
   });
 
   let newServer = '';
   let newName = '';
   let newPassword = '';
   let settingsOpen = false;
+  let error: string | null = null;
+  let copiedServer: string | null = null;
+  let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
+  function clearCopyTimeout() {
+    if (copyTimeout) {
+      clearTimeout(copyTimeout);
+      copyTimeout = null;
+    }
+  }
 
   function add() {
-    if (newServer.trim()) {
-      const entry: ServerEntry = { url: normalizeServerUrl(newServer), name: newName.trim() || newServer };
-      if (newPassword.trim()) entry.password = newPassword;
-      servers.add(entry);
-      newServer = '';
-      newName = '';
-      newPassword = '';
+    error = null;
+    const rawServer = newServer.trim();
+    if (!rawServer) {
+      error = 'Enter a server address or invite link.';
+      return;
     }
+
+    const trimmedName = newName.trim();
+    const trimmedPassword = newPassword.trim();
+    let entry: ServerEntry;
+
+    if (rawServer.startsWith('murmer://')) {
+      const parsed = parseInviteLink(rawServer);
+      if (!parsed) {
+        error = 'That invite link could not be parsed.';
+        return;
+      }
+      entry = {
+        url: parsed.url,
+        name: trimmedName || parsed.name || parsed.url
+      };
+      const password = trimmedPassword || parsed.password;
+      if (password) {
+        entry.password = password;
+      }
+    } else {
+      entry = {
+        url: normalizeServerUrl(rawServer),
+        name: trimmedName || rawServer
+      };
+      if (trimmedPassword) {
+        entry.password = trimmedPassword;
+      }
+    }
+
+    servers.add(entry);
+    newServer = '';
+    newName = '';
+    newPassword = '';
   }
 
   function join(server: ServerEntry) {
@@ -56,6 +98,41 @@
   function closeSettings() {
     settingsOpen = false;
   }
+
+  async function copyInvite(server: ServerEntry) {
+    error = null;
+    const invite = createInviteLink(server);
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(invite);
+      } else if (typeof document !== 'undefined') {
+        const textarea = document.createElement('textarea');
+        textarea.value = invite;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      } else {
+        throw new Error('Clipboard API not available');
+      }
+      copiedServer = server.url;
+      clearCopyTimeout();
+      copyTimeout = setTimeout(() => {
+        if (copiedServer === server.url) {
+          copiedServer = null;
+        }
+        copyTimeout = null;
+      }, 2000);
+    } catch (err) {
+      error = 'Could not copy the invite link. Please copy it manually.';
+      if (import.meta.env.DEV) {
+        console.error('Failed to copy invite link', err);
+      }
+    }
+  }
 </script>
 
 <div class="servers-page">
@@ -70,15 +147,22 @@
   <SettingsModal open={settingsOpen} close={closeSettings} />
   <form class="add" on:submit|preventDefault={add}>
     <input bind:value={newName} placeholder="Server name" />
-    <input bind:value={newServer} placeholder="host:port or ws://url" />
+    <input bind:value={newServer} placeholder="host:port, ws://url or invite link" />
     <input type="password" bind:value={newPassword} placeholder="Password (optional)" />
     <button type="submit">Add</button>
   </form>
+  {#if error}
+    <div class="error">{error}</div>
+  {/if}
   <ul class="list">
     {#each $servers as server}
       <li>
         <button on:click={() => join(server)} title={server.url}>{server.name}</button>
         <StatusDot online={$serverStatus[server.url]} />
+        <button class="secondary" type="button" on:click={() => copyInvite(server)}>Copy invite</button>
+        {#if copiedServer === server.url}
+          <span class="copied">Copied!</span>
+        {/if}
         <button class="del" on:click={() => removeServer(server.url)}>Delete</button>
       </li>
     {/each}
@@ -137,6 +221,17 @@
     background: var(--color-error);
   }
 
+  button.secondary {
+    background: var(--color-panel-elevated);
+    color: var(--color-text);
+    border: 1px solid var(--color-border-subtle);
+  }
+
+  button.secondary:hover {
+    background: var(--color-bg-elevated);
+    border-color: var(--color-border);
+  }
+
   button:hover {
     background: var(--color-accent-hover);
     transform: translateY(-1px);
@@ -145,6 +240,21 @@
 
   button.del:hover {
     background: #dc2626;
+  }
+
+  .error {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    background: rgba(239, 68, 68, 0.15);
+    border: 1px solid rgba(239, 68, 68, 0.35);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+  }
+
+  .copied {
+    color: var(--color-success);
+    font-size: 0.9rem;
+    font-weight: 600;
   }
 
   .list {


### PR DESCRIPTION
## Summary
- add helpers to generate and parse murmer:// invite links
- allow the servers page to accept invites, copy shareable links, and show inline feedback
- adjust the voice activity analyser buffer typing for TypeScript compatibility and mark the TODO item complete

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d96a72198c832782b4567fbfc4220a