### PR TITLE
Hide native file input button

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1346,6 +1346,18 @@
     font-size: 0.78rem;
   }
 
+  .file-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .file-button,
   .send {
     width: 2.75rem;


### PR DESCRIPTION
## Summary
- hide the native file input control so only the custom upload button remains visible
- keep the input accessible by using a visually hidden style pattern

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d978b2f9a083279dfc878f4faf35c4