### PR TITLE
Fix chat window scrollbar overlap

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1354,6 +1354,7 @@
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    scrollbar-gutter: stable both-edges;
     display: flex;
     flex-direction: column;
     gap: 0.8rem;


### PR DESCRIPTION
## Summary
- reserve a stable gutter for the chat message list scrollbar to keep it within the container

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d97d0e4b088327a55985bba1cb64b1