### PR TITLE
Add day separators to chat history

### DIFF
--- a/murmer_client/src/lib/stores/chat.ts
+++ b/murmer_client/src/lib/stores/chat.ts
@@ -24,6 +24,20 @@ function createChatStore() {
 
   function prepareMessage(raw: Message): Message {
     const msg: Message = { ...raw };
+    if (typeof msg.timestamp === 'string') {
+      const parsed = Date.parse(msg.timestamp);
+      if (!Number.isNaN(parsed)) {
+        const date = new Date(parsed);
+        msg.timestamp = date.toISOString();
+        if (!msg.time) {
+          msg.time = date.toLocaleTimeString();
+        }
+      } else {
+        msg.timestamp = undefined;
+      }
+    } else if (msg.timestamp !== undefined) {
+      msg.timestamp = undefined;
+    }
     if (!msg.time) {
       msg.time = new Date().toLocaleTimeString();
     }
@@ -136,7 +150,14 @@ function createChatStore() {
 
   function send(user: string, text: string) {
     if (socket && socket.readyState === WebSocket.OPEN) {
-      const payload = { type: 'chat', user, text, time: new Date().toLocaleTimeString() };
+      const now = new Date();
+      const payload = {
+        type: 'chat',
+        user,
+        text,
+        time: now.toLocaleTimeString(),
+        timestamp: now.toISOString()
+      };
       if (import.meta.env.DEV) console.log('Sending:', payload);
       socket.send(JSON.stringify(payload));
     }

--- a/murmer_client/src/lib/types.ts
+++ b/murmer_client/src/lib/types.ts
@@ -3,6 +3,7 @@ export interface Message {
   user?: string;
   text?: string;
   time?: string;
+  timestamp?: string;
   channel?: string;
   id?: number;
   messages?: Message[];


### PR DESCRIPTION
## Summary
- add timestamp metadata to client chat messages so their dates are available
- render day separators in the chat page whenever the calendar day changes and style the separator
- ensure the server normalizes timestamps and backfills a time string for stored chat messages

## Testing
- npm run check
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d97d55dfc08327b81dfb73cea1193f