### PR TITLE
Add code syntax highlighting for chat messages

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Use the checkboxes to track progress.
 - [ ] Channel categories and folders
 - [x] Channel description/topics
 - [ ] Channel permissions and moderation
-- [ ] Code syntax highlighting
+- [x] Code syntax highlighting
 - [ ] Direct messages between users
 - [ ] Enable deleting messages
 - [ ] Ephemeral messages that auto-delete

--- a/murmer_client/package-lock.json
+++ b/murmer_client/package-lock.json
@@ -14,6 +14,7 @@
         "@tauri-apps/plugin-opener": "^2.5.0",
         "@tauri-apps/plugin-window-state": "^2.4.0",
         "dompurify": "^3.2.7",
+        "highlight.js": "^11.11.1",
         "marked": "^16.3.0",
         "tweetnacl": "^1.0.3"
       },
@@ -1402,6 +1403,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/is-reference": {

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -18,6 +18,7 @@
     "@tauri-apps/plugin-opener": "^2.5.0",
     "@tauri-apps/plugin-window-state": "^2.4.0",
     "dompurify": "^3.2.7",
+    "highlight.js": "^11.11.1",
     "marked": "^16.3.0",
     "tweetnacl": "^1.0.3"
   },

--- a/murmer_client/src/lib/markdown.ts
+++ b/murmer_client/src/lib/markdown.ts
@@ -1,5 +1,47 @@
 import { marked } from 'marked';
+import type { Tokens } from 'marked';
 import DOMPurify from 'dompurify';
+import hljs from 'highlight.js/lib/common';
+
+const renderer = new marked.Renderer();
+const defaultCodeRenderer = renderer.code.bind(renderer);
+
+renderer.code = ({ text, lang, escaped }: Tokens.Code) => {
+  const normalized = (lang ?? '').trim().split(/\s+/)[0]?.toLowerCase() ?? '';
+
+  const buildBlock = (value: string, language: string | undefined) => {
+    const languageClass = language ? ` language-${language}` : normalized ? ` language-${normalized}` : '';
+    return `<pre><code class="hljs${languageClass}">${value}</code></pre>`;
+  };
+
+  if (normalized && hljs.getLanguage(normalized)) {
+    try {
+      const result = hljs.highlight(text, { language: normalized, ignoreIllegals: true });
+      return buildBlock(result.value, result.language ?? normalized);
+    } catch (error) {
+      console.warn('Failed to highlight code block', error);
+    }
+  }
+
+  try {
+    const result = hljs.highlightAuto(text);
+    if (result?.value) {
+      return buildBlock(result.value, result.language);
+    }
+  } catch (error) {
+    console.warn('Failed to auto-highlight code block', error);
+  }
+
+  return defaultCodeRenderer({
+    type: 'code',
+    raw: text,
+    text,
+    lang,
+    escaped
+  });
+};
+
+marked.use({ renderer });
 
 export function renderMarkdown(text: string): string {
   // Use parseInline for simple text to avoid wrapping in <p> tags

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1523,6 +1523,63 @@
     border: 1px solid color-mix(in srgb, var(--color-primary) 18%, transparent);
   }
 
+  .message .content :global(pre code) {
+    display: block;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    font-size: 0.9em;
+  }
+
+  .message .content :global(.hljs) {
+    color: var(--color-on-surface);
+  }
+
+  .message .content :global(.hljs-comment),
+  .message .content :global(.hljs-quote) {
+    color: color-mix(in srgb, var(--color-muted) 92%, transparent);
+    font-style: italic;
+  }
+
+  .message .content :global(.hljs-keyword),
+  .message .content :global(.hljs-selector-tag),
+  .message .content :global(.hljs-subst) {
+    color: color-mix(in srgb, var(--color-secondary) 80%, var(--color-on-surface) 20%);
+  }
+
+  .message .content :global(.hljs-string),
+  .message .content :global(.hljs-doctag),
+  .message .content :global(.hljs-regexp) {
+    color: color-mix(in srgb, var(--color-tertiary) 80%, var(--color-on-surface) 20%);
+  }
+
+  .message .content :global(.hljs-title),
+  .message .content :global(.hljs-section),
+  .message .content :global(.hljs-function),
+  .message .content :global(.hljs-name) {
+    color: color-mix(in srgb, var(--color-primary) 78%, var(--color-on-surface) 22%);
+  }
+
+  .message .content :global(.hljs-number),
+  .message .content :global(.hljs-literal),
+  .message .content :global(.hljs-symbol),
+  .message .content :global(.hljs-bullet) {
+    color: color-mix(in srgb, var(--color-warning) 75%, var(--color-on-surface) 25%);
+  }
+
+  .message .content :global(.hljs-attr),
+  .message .content :global(.hljs-attribute),
+  .message .content :global(.hljs-variable),
+  .message .content :global(.hljs-template-variable) {
+    color: color-mix(in srgb, var(--color-success) 75%, var(--color-on-surface) 25%);
+  }
+
+  .message .content :global(.hljs-meta),
+  .message .content :global(.hljs-meta .hljs-string) {
+    color: color-mix(in srgb, var(--color-primary) 65%, var(--color-on-surface) 35%);
+  }
+
   .message img {
     max-width: min(420px, 100%);
     border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- integrate highlight.js when rendering markdown so chat code blocks receive syntax highlighting
- style highlighted tokens with Murmer theme colors for both light and dark modes
- mark the TODO entry for code syntax highlighting as complete

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d996fce5f08327bcb41348cc735ee6