### PR TITLE
Harden channel management and refresh docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,36 @@
 # Contributor Guide
 
-This repository hosts **Murmer**, a minimal voice and text chat prototype.
-It is split into a Tauri/SvelteKit client and a Rust server.
+This monorepo hosts **Murmer**, a desktop chat prototype split into a
+Tauri/SvelteKit client (`murmer_client/`) and an Axum-based Rust server
+(`murmer_server/`). Each directory contains its own `AGENTS.md` with tooling
+specifics.
 
-## Repository Structure
-- `murmer_client/` – desktop client built with Tauri and SvelteKit.
-- `murmer_server/` – Rust WebSocket server that persists chat messages to Postgres.
-- `docker-compose.yml` – runs the server together with Postgres.
+## Workflow overview
+- Install the latest [Rust toolchain](https://www.rust-lang.org/tools/install)
+  and [Node.js 22+](https://nodejs.org).
+- See `README.md` for detailed setup, build and configuration instructions.
+- When developing locally run the client with `npm run tauri dev` and the server
+  with `cargo run` or `docker compose up --build`.
 
-Each subfolder contains its own `AGENTS.md` with more details.
+## Quality checks
+- Run `cargo check` inside `murmer_server/` and format with `cargo fmt`.
+- Run `npm run check` inside `murmer_client/` for Svelte + TypeScript diagnostics.
+- Document complex security-sensitive logic with inline comments.
+- Sanitize or validate all user-supplied data before acting on it.
 
-## Getting Started
-1. Install [Rust](https://www.rust-lang.org/tools/install) and [Node.js](https://nodejs.org) 22+.
-2. See `README.md` for quick commands to run the client and server.
-
-## Security Considerations
-- The server implements Ed25519 signature-based authentication with anti-replay protection
-- Rate limiting is enforced for authentication attempts and message sending
-- File uploads are restricted to images only with size limits and type validation
-- Input validation is performed on channel names, usernames, and message content
-- CORS is configured restrictively in production builds
-
-## Code Quality Standards
-- All Rust code must pass `cargo check` and be formatted with `cargo fmt`
-- Frontend code should pass `npm run check` for TypeScript and Svelte validation
-- Complex functions should include inline documentation explaining security implications
-- All user inputs must be validated and sanitized
-
-## Validation
-- There is currently no automated test suite
-- Run `npm run check` inside `murmer_client` to perform Svelte/TypeScript checks
-- Run `cargo check` in `murmer_server` to ensure it builds successfully
-- Format Rust code with `cargo fmt` before committing
-- Test the application manually after making changes to core security or networking code
-
-## Docker
-Use `docker compose up --build` to start the server and a Postgres database defined in `docker-compose.yml`.
+## Security expectations
+- Authentication relies on Ed25519 signatures with replay protection.
+- Rate limiting exists for both authentication and chat traffic.
+- File uploads are restricted to images and validated by content-type and size.
+- Channel management honours role assignments when `ADMIN_TOKEN` is configured.
+- Production deployments should keep CORS disabled unless explicitly required.
 
 ## Versioning
-Murmer uses date-based pre-release versions such as `2025.7.13-alpha.1`.
-When asked to **bump the version**, follow these steps:
-1. Determine today's date in `YYYY.M.D` format.
-2. If a tag `YYYY.M.D-alpha.1` already exists, increment the numeric
-   suffix (`alpha.2`, `alpha.3`, ...). Otherwise start with `alpha.1`.
-3. Replace the old version in:
+Murmer uses date-based pre-release versions (`YYYY.M.D-alpha.N`). When asked to
+bump versions:
+
+1. Derive the new version string.
+2. Update the version fields in:
    - `murmer_client/package.json`
    - `murmer_client/package-lock.json`
    - `murmer_client/src-tauri/Cargo.toml`
@@ -51,5 +38,11 @@ When asked to **bump the version**, follow these steps:
    - `murmer_client/src-tauri/tauri.conf.json`
    - `murmer_server/Cargo.toml`
    - `murmer_server/Cargo.lock`
-4. Commit the changes with a message like `Bump version to <new version>`
-   and create a git tag with the same version string.
+3. Commit with `Bump version to <new version>` and create a matching git tag.
+
+## Validation checklist
+- Ensure CI-equivalent commands above pass before opening a pull request.
+- Perform manual smoke tests after changing networking, authentication or file
+  handling logic.
+- Keep documentation (`README.md`, `AGENTS.md`, `TODO.md`) in sync with code
+  behaviour.

--- a/murmer_client/AGENTS.md
+++ b/murmer_client/AGENTS.md
@@ -1,44 +1,43 @@
 # Murmer Client Guide
 
-This directory contains the Tauri/SvelteKit desktop client for the Murmer chat application.
+The desktop client is built with **SvelteKit 2** and ships inside a **Tauri 2**
+shell. This document outlines the most common workflows for contributors.
 
-## Architecture Overview
-- **Frontend**: SvelteKit 2.x with TypeScript for the web interface
-- **Desktop Shell**: Tauri 2.x for native desktop integration
-- **State Management**: Svelte stores for reactive state management
-- **Communication**: WebSocket connection to the Rust server
-- **Cryptography**: Ed25519 signatures for authentication (using tweetnacl)
-- **UI**: Markdown support for rich text with DOMPurify sanitization
+## Development commands
+- `npm install` – install/update dependencies and refresh `package-lock.json`
+- `npm run dev` – run the Svelte dev server with hot module reloading
+- `npm run tauri dev` – launch the desktop shell backed by the dev server
+- `npm run build` – produce static assets consumed by Tauri
+- `npm run tauri build` – package installers/bundles for distribution
+- `npm run check` – TypeScript + Svelte diagnostics (run before committing)
 
-## Setup
-1. Run `npm install` to install dependencies
-2. Launch the app with `npm run tauri dev` for development
-3. Build for production with `npm run tauri build`
+The Tauri configuration in `src-tauri/tauri.conf.json` invokes `npm run dev`
+when you start the shell in development mode.
 
-The Tauri configuration in `src-tauri/tauri.conf.json` runs `npm run dev` during development.
+## Code organisation
+- `src/routes/` – SvelteKit pages (login, server selection, chat)
+- `src/lib/components/` – reusable UI primitives
+- `src/lib/stores/` – Svelte stores holding client state
+- `src/lib/voice/` – WebRTC helpers and push-to-talk tooling
+- `src-tauri/` – Rust-side glue for native integrations
 
-## Security Notes
-- Private keys are stored in localStorage (consider more secure storage for production)
-- WebSocket messages should be validated before processing
-- Markdown rendering uses DOMPurify but should be regularly updated
-- Content Security Policy should be configured in production
+Document complex components with HTML comments at the top of the file and prefer
+small, composable Svelte components. Re-export shared utilities from
+`src/lib/index.ts` if they need to be consumed in multiple places.
 
-## File Structure
-- `src/routes/` - SvelteKit pages (login, chat, servers)
-- `src/lib/components/` - Reusable Svelte components
-- `src/lib/stores/` - Reactive state management
-- `src/lib/voice/` - WebRTC voice chat implementation
-- `src-tauri/` - Rust code for desktop integration
+## Security considerations
+- Key pairs are stored in `localStorage`; treat this as acceptable for the
+  prototype but evaluate more secure storage for production.
+- Always validate server responses before mutating client state.
+- DOMPurify sanitises Markdown output – keep the dependency up to date.
+- Avoid `{@html ...}` unless the content is sanitised explicitly.
 
-## Development Guidelines
-- Use TypeScript for all new code
-- Validate all user inputs and server responses
-- Follow Svelte best practices for reactive programming
-- Test WebSocket reconnection and error scenarios
+## Rust (Tauri) side
+The native shell lives in `src-tauri/`. Run `cargo check` there after making
+changes. Keep the Rust code minimal – prefer implementing features in Svelte
+unless native APIs are required.
 
-## Validation
-- Run `npm run check` to perform Svelte and TypeScript checks
-- The Rust code in `src-tauri` should compile successfully with `cargo check`
-- Test the built application on the target platforms
-- Verify WebSocket connectivity and authentication flows
-- There are no automated tests yet - this should be added for production use
+## QA checklist
+- Run `npm run check` before submitting changes.
+- Exercise the reconnect flow and authentication failure cases manually.
+- Verify that push-to-talk works with the configured keybinding on Windows.

--- a/murmer_client/src/lib/components/ContextMenu.svelte
+++ b/murmer_client/src/lib/components/ContextMenu.svelte
@@ -1,3 +1,7 @@
+<!--
+  Generic floating context menu used across chat lists. Accepts a list of menu
+  items and exposes coordinates for positioning relative to the user's cursor.
+-->
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   export let items: { label: string; action: () => void }[] = [];

--- a/murmer_client/src/lib/components/StatusDot.svelte
+++ b/murmer_client/src/lib/components/StatusDot.svelte
@@ -1,3 +1,4 @@
+<!-- Small indicator used in the server list to show online/offline status. -->
 <script lang="ts">
   export let online: boolean | null = null;
   $: color = online === null ? '#6b7280' : online ? '#22c55e' : '#dc2626';

--- a/murmer_client/src/routes/+layout.svelte
+++ b/murmer_client/src/routes/+layout.svelte
@@ -1,3 +1,7 @@
+<!--
+  Root layout for the Murmer desktop client. It initialises the theme store on
+  mount and injects shared typography and colour tokens for every page.
+-->
 <script lang="ts">
   import { onMount } from 'svelte';
   import { APP_VERSION } from '$lib/version';

--- a/murmer_client/src/routes/+page.svelte
+++ b/murmer_client/src/routes/+page.svelte
@@ -1,3 +1,8 @@
+<!--
+  Landing route that immediately redirects the user to the login screen. This
+  keeps the root URL stable while delegating all logic to the dedicated
+  `/login` page.
+-->
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -1,3 +1,8 @@
+<!--
+  Primary chat surface. Handles WebSocket lifecycle, message rendering, voice
+  channel state and peripheral UI such as sidebars and context menus. The
+  module coordinates many Svelte stores to keep the interface reactive.
+-->
 <script lang="ts">
   import { onMount, onDestroy, afterUpdate, tick } from 'svelte';
   import { chat } from '$lib/stores/chat';

--- a/murmer_client/src/routes/login/+page.svelte
+++ b/murmer_client/src/routes/login/+page.svelte
@@ -1,3 +1,8 @@
+<!--
+  Login page for Murmer. Users supply a display name that is persisted in the
+  session store and then redirected to their server list. The page guards
+  against authenticated users revisiting the login screen.
+-->
 <script lang="ts">
   import { session } from '$lib/stores/session';
   import { goto } from '$app/navigation';

--- a/murmer_client/src/routes/servers/+page.svelte
+++ b/murmer_client/src/routes/servers/+page.svelte
@@ -1,3 +1,8 @@
+<!--
+  Server selector and management screen. Users can add, edit and remove server
+  entries, manage invite links and open the settings modal. The view also keeps
+  server reachability indicators up to date.
+-->
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { servers, selectedServer, type ServerEntry } from '$lib/stores/servers';

--- a/murmer_server/src/main.rs
+++ b/murmer_server/src/main.rs
@@ -153,5 +153,10 @@ async fn main() {
     info!("WebSocket server running on {addr}");
 
     let listener = TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
## Summary
- enforce role-based permissions on text and voice channel management and rate-limit auth attempts by real client IPs
- document major Svelte routes/components and refresh the project README with updated workflows
- rewrite AGENTS.md guides for the repo, client, and server to clarify expectations and security notes

## Testing
- cargo check
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d99b2927308327bcda16dd7cd5a541