### PR TITLE
Fix Linux Snap LD_LIBRARY_PATH conflict for Tauri dev

### DIFF
--- a/murmer_client/README.md
+++ b/murmer_client/README.md
@@ -13,6 +13,13 @@ npm run tauri dev
 
 Running `npm run tauri dev` starts the SvelteKit dev server and opens the Tauri shell with hot reloading.
 
+> [!NOTE]
+> On Linux systems with Snap installed we strip any `/snap/core*` entries from
+> `LD_LIBRARY_PATH` before launching the Tauri CLI. This avoids runtime errors
+> such as `undefined symbol: __libc_pthread_init` caused by mixing the Snap
+> glibc with the system toolchain. If you invoke the Tauri CLI manually, ensure
+> that environment variable is unset or similarly cleaned.
+
 ## Stores
 
 Several Svelte stores persist client state:

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "tauri": "tauri"
+    "tauri": "node ./scripts/run-tauri.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/murmer_client/scripts/run-tauri.js
+++ b/murmer_client/scripts/run-tauri.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const env = { ...process.env };
+
+if (process.platform === 'linux') {
+  const originalLdLibraryPath = env.LD_LIBRARY_PATH;
+  if (originalLdLibraryPath) {
+    const cleanedEntries = originalLdLibraryPath
+      .split(':')
+      .filter((entry) => entry && !/\/snap\/core\d+/.test(entry));
+
+    if (cleanedEntries.length === 0) {
+      delete env.LD_LIBRARY_PATH;
+    } else {
+      env.LD_LIBRARY_PATH = cleanedEntries.join(':');
+    }
+  }
+}
+
+const child = spawn('tauri', args, {
+  env,
+  stdio: 'inherit'
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error('[murmer] Failed to launch Tauri CLI:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- wrap the Tauri CLI in a Node helper that strips Snap core paths from `LD_LIBRARY_PATH` on Linux
- update the package script to use the helper and document the behaviour in the client README

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68da4b58accc8327ab1373aec99fdf99