### PR TITLE
Fix tauri dev runner leaking snap environment variables

### DIFF
--- a/murmer_client/scripts/run-tauri.js
+++ b/murmer_client/scripts/run-tauri.js
@@ -17,6 +17,12 @@ if (process.platform === 'linux') {
       env.LD_LIBRARY_PATH = cleanedEntries.join(':');
     }
   }
+
+  for (const key of Object.keys(env)) {
+    if (key === 'SNAP' || key.startsWith('SNAP_')) {
+      delete env[key];
+    }
+  }
 }
 
 const child = spawn('tauri', args, {


### PR DESCRIPTION
## Summary
- remove snap-specific environment variables when spawning the Tauri CLI on Linux so the runtime links against the system glibc

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da4f5886488327975fa919efc88b25