### PR TITLE
Add configurable voice channel quality settings

### DIFF
--- a/murmer_client/src/lib/stores/voice.ts
+++ b/murmer_client/src/lib/stores/voice.ts
@@ -1,5 +1,5 @@
 import { writable, derived, get } from 'svelte/store';
-import type { RemotePeer, ConnectionStats } from '../types';
+import type { RemotePeer, ConnectionStats, VoiceChannelInfo } from '../types';
 import { VoiceManager } from '../voice/manager';
 
 const peers = writable<RemotePeer[]>([]);
@@ -8,7 +8,8 @@ manager.subscribe((list) => peers.set(list));
 
 export const voice = {
   subscribe: peers.subscribe,
-  join: (user: string, channel: string) => manager.join(user, channel, get(peers)),
+  join: (user: string, channel: string, info?: VoiceChannelInfo) =>
+    manager.join(user, channel, get(peers), info),
   leave: (channel: string) => manager.leave(channel, get(peers))
 };
 

--- a/murmer_client/src/lib/stores/voiceChannels.ts
+++ b/murmer_client/src/lib/stores/voiceChannels.ts
@@ -1,40 +1,89 @@
 import { writable } from 'svelte/store';
 import { chat } from './chat';
-import type { Message } from '../types';
+import type { Message, VoiceChannelInfo } from '../types';
+
+function normalizeChannel(value: any): VoiceChannelInfo | null {
+  if (!value || typeof value !== 'object') return null;
+  const name = typeof value.name === 'string' ? value.name : typeof value.channel === 'string' ? value.channel : null;
+  if (!name) return null;
+  const quality = typeof value.quality === 'string' && value.quality.trim() ? value.quality.trim() : 'standard';
+  let bitrate: number | null = null;
+  if (value.bitrate === null || value.bitrate === undefined) {
+    bitrate = null;
+  } else if (typeof value.bitrate === 'number' && Number.isFinite(value.bitrate)) {
+    bitrate = Math.max(0, Math.round(value.bitrate));
+  } else if (typeof value.bitrate === 'string') {
+    const parsed = Number(value.bitrate);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      bitrate = Math.max(0, Math.round(parsed));
+    }
+  }
+  return { name, quality, bitrate };
+}
 
 function createVoiceChannelStore() {
-  const { subscribe, set, update } = writable<string[]>([]);
+  const { subscribe, set, update } = writable<VoiceChannelInfo[]>([]);
 
   chat.on('voice-channel-list', (msg: Message) => {
     const list = (msg as any).channels;
     if (Array.isArray(list)) {
-      set(list as string[]);
+      const items = list
+        .map((item) => normalizeChannel(item))
+        .filter((item): item is VoiceChannelInfo => Boolean(item));
+      set(items);
     }
   });
 
   chat.on('voice-channel-add', (msg: Message) => {
-    const name = (msg as any).channel;
-    if (typeof name === 'string') {
-      update((chs) => (chs.includes(name) ? chs : [...chs, name]));
+    const info = normalizeChannel(msg as any);
+    if (info) {
+      update((chs) => {
+        const existing = chs.find((c) => c.name === info.name);
+        return existing ? chs : [...chs, info];
+      });
+    }
+  });
+
+  chat.on('voice-channel-update', (msg: Message) => {
+    const info = normalizeChannel(msg as any);
+    if (info) {
+      update((chs) =>
+        chs.map((c) => (c.name === info.name ? { ...c, quality: info.quality, bitrate: info.bitrate } : c))
+      );
     }
   });
 
   chat.on('voice-channel-remove', (msg: Message) => {
     const name = (msg as any).channel;
     if (typeof name === 'string') {
-      update((chs) => chs.filter((c) => c !== name));
+      update((chs) => chs.filter((c) => c.name !== name));
     }
   });
 
-  function create(name: string) {
-    chat.sendRaw({ type: 'create-voice-channel', name });
+  function create(name: string, preset?: Pick<VoiceChannelInfo, 'quality' | 'bitrate'>) {
+    const payload: Record<string, unknown> = { type: 'create-voice-channel', name };
+    if (preset) {
+      payload.quality = preset.quality;
+      payload.bitrate = preset.bitrate ?? null;
+    }
+    chat.sendRaw(payload);
+  }
+
+  function configure(name: string, preset: Pick<VoiceChannelInfo, 'quality' | 'bitrate'>) {
+    const payload: Record<string, unknown> = {
+      type: 'update-voice-channel',
+      name,
+      quality: preset.quality,
+      bitrate: preset.bitrate ?? null
+    };
+    chat.sendRaw(payload);
   }
 
   function remove(name: string) {
     chat.sendRaw({ type: 'delete-voice-channel', name });
   }
 
-  return { subscribe, set, create, remove };
+  return { subscribe, set, create, configure, remove };
 }
 
 export const voiceChannels = createVoiceChannelStore();

--- a/murmer_client/src/lib/types.ts
+++ b/murmer_client/src/lib/types.ts
@@ -29,3 +29,9 @@ export interface RoleInfo {
 }
 
 export type UserStatus = 'online' | 'away' | 'busy' | 'offline';
+
+export interface VoiceChannelInfo {
+  name: string;
+  quality: string;
+  bitrate: number | null;
+}


### PR DESCRIPTION
## Summary
- persist voice channel quality/bitrate metadata in the server and database
- allow privileged users to create and update voice channel quality levels via websocket events
- surface voice quality presets in the client UI and apply bitrate caps in the voice manager

## Testing
- cargo check
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dae4e96c748327a89aebbc70b50a77