### PR TITLE
Enhance chat channel management and scrolling behavior

### DIFF
--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -281,6 +281,7 @@
   let inVoice = false;
   let settingsOpen = false;
   let currentChatChannelId: number = 0;
+  let initialChannelSet = false;
   let currentVoiceChannelId: number | null = null;
   let currentTopic = '';
   $: currentChatChannelName = $channels.find(c => c.id === currentChatChannelId)?.name ?? '';
@@ -310,7 +311,12 @@
 
   $: if ($channels.length && !$channels.some((c) => c.id === currentChatChannelId)) {
     currentChatChannelId = $channels[0].id;
-    chat.sendRaw({ type: 'join', channelId: currentChatChannelId });
+    loadingHistory = false;
+    if (initialChannelSet) {
+      chat.sendRaw({ type: 'join', channelId: currentChatChannelId });
+    } else {
+      initialChannelSet = true;
+    }
   }
 
   $: currentTopic = $channelTopics[currentChatChannelId] ?? '';
@@ -767,6 +773,7 @@
     currentChatChannelId = id;
     statusMenuOpen = false;
     notificationMenuOpen = false;
+    loadingHistory = false;
     chat.clear();
     chat.sendRaw({ type: 'join', channelId: id });
     scrollBottom();
@@ -1178,12 +1185,13 @@
   async function scrollBottom() {
     await tick();
     if (messagesContainer) {
-      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+      setScrollTop(messagesContainer.scrollHeight);
     }
   }
   let lastLength = 0;
   let loadingHistory = false;
   let prevHeight = 0;
+  let programmaticScroll = false;
 
   function earliestId(): number | null {
     let min: number | null = null;
@@ -1195,8 +1203,15 @@
     return min;
   }
 
+  function setScrollTop(value: number) {
+    if (!messagesContainer) return;
+    programmaticScroll = true;
+    messagesContainer.scrollTop = value;
+    requestAnimationFrame(() => { programmaticScroll = false; });
+  }
+
   function onScroll() {
-    if (!messagesContainer || loadingHistory) return;
+    if (!messagesContainer || loadingHistory || programmaticScroll) return;
     if (messagesContainer.scrollTop < 100) {
       const id = earliestId();
       if (id !== null && id > 1) {
@@ -1210,7 +1225,7 @@
   const handleHistory = async () => {
     await tick();
     if (messagesContainer) {
-      messagesContainer.scrollTop = messagesContainer.scrollHeight - prevHeight;
+      setScrollTop(messagesContainer.scrollHeight - prevHeight);
     }
     loadingHistory = false;
     if (pendingScrollToMessage !== null) {
@@ -1247,7 +1262,7 @@
       if (filteredLength !== lastLength) {
         lastLength = filteredLength;
         if (!loadingHistory && !handledPending) {
-          messagesContainer.scrollTop = messagesContainer.scrollHeight;
+          setScrollTop(messagesContainer.scrollHeight);
         }
       }
     }

--- a/murmer_server/src/db/messages.rs
+++ b/murmer_server/src/db/messages.rs
@@ -102,10 +102,8 @@ pub async fn send_history(
                     msgs.push(val);
                 }
             }
-            if !msgs.is_empty() {
-                let payload = serde_json::json!({"type": "history", "messages": msgs});
-                let _ = sender.send(Message::Text(payload.to_string())).await;
-            }
+            let payload = serde_json::json!({"type": "history", "messages": msgs});
+            let _ = sender.send(Message::Text(payload.to_string())).await;
         }
         Err(e) => error!("db history error: {e}"),
     }


### PR DESCRIPTION
This commit introduces a new flag to track the initial channel setup in the chat component, ensuring that the join command is only sent after the first channel is set. Additionally, it refactors the scrolling logic to use a dedicated function for setting the scroll position, improving the handling of programmatic scrolling and loading history. The server-side message history retrieval has also been streamlined to always send the history payload, enhancing the reliability of message delivery.