### PR TITLE
Allow entering a hex code for the theme color

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,29 @@ Use the checkboxes to track progress.
 - [ ] User nicknames per server
 - [ ] User profiles/avatars
 
+### 📚 Channel Wiki
+
+Every channel can host a Markdown-based wiki with multiple pages. Pages are
+identified by a slug that is unique per channel and addressed as
+`channel/page-slug`. Wiki links use `[[page]]` for pages in the same channel
+and `[[channel/page]]` for pages in other channels; links to missing pages
+render as "create page" stubs. Content is stored server-side in SQLite and
+synced to clients; editing is role-gated like other channel management.
+
+- [ ] Server: `wiki_pages` table (channel id, slug, title, Markdown body, author, updated_at, revision counter) with per-channel slug uniqueness
+- [ ] Server: `wiki_revisions` table storing previous versions for history/rollback
+- [ ] Server: CRUD API (list pages of a channel, get, create, update, delete, rename) over the existing WS protocol, with validation and size limits on page content
+- [ ] Server: role-gated write permissions (reuse channel moderation roles); read access for everyone who can see the channel
+- [ ] Server: resolve endpoint for `[[channel/page]]` links (existence check for stub rendering) and cleanup when a channel is deleted
+- [ ] Server: index wiki pages in the FTS5 full-text search alongside messages
+- [ ] Client: wiki panel/tab in the chat view with a per-channel page list and page viewer
+- [ ] Client: Markdown editor with live preview (reuse `src/lib/markdown.ts`), save/cancel and conflict warning on concurrent edits
+- [ ] Client: `[[...]]` wiki-link syntax in the Markdown renderer — same-channel and cross-channel navigation, red/stub styling for missing pages
+- [ ] Client: create/rename/delete pages via context menu, honoring server-side permissions
+- [ ] Client: revision history view with diff and restore
+- [ ] Client: wiki pages included in the search UI results
+- [ ] Sanitize rendered wiki HTML (same hardening as chat Markdown, no active content)
+
 ### 🎤 Voice Features
 
 - [ ] Breakout rooms

--- a/murmer_client/package.json
+++ b/murmer_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmer",
-  "version": "2026.713.0",
+  "version": "2026.714.0",
   "description": "",
   "type": "module",
   "scripts": {

--- a/murmer_client/src-tauri/Cargo.lock
+++ b/murmer_client/src-tauri/Cargo.lock
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_client"
-version = "2026.713.0"
+version = "2026.714.0"
 dependencies = [
  "glib 0.22.8",
  "serde",

--- a/murmer_client/src-tauri/Cargo.toml
+++ b/murmer_client/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_client"
-version = "2026.713.0"
+version = "2026.714.0"
 description = "Murmer desktop client (Tauri shell)"
 edition = "2021"
 

--- a/murmer_client/src-tauri/src/lib.rs
+++ b/murmer_client/src-tauri/src/lib.rs
@@ -60,7 +60,15 @@ pub fn run() -> tauri::Result<()> {
             let open = MenuItemBuilder::with_id("open", "Open").build(app)?;
             let quit = MenuItemBuilder::with_id("quit", "Close").build(app)?;
             let tray_menu = MenuBuilder::new(app).item(&open).item(&quit).build()?;
-            TrayIconBuilder::new().menu(&tray_menu).build(app)?;
+            // The tray icon is built here instead of being declared via
+            // `app.trayIcon` in tauri.conf.json: that config makes Tauri create
+            // its own menu-less tray icon on top of this one, leaving two
+            // entries in the notification area.
+            let mut tray = TrayIconBuilder::new().menu(&tray_menu).tooltip("Murmer");
+            if let Some(icon) = app.default_window_icon() {
+                tray = tray.icon(icon.clone());
+            }
+            tray.build(app)?;
             Ok(())
         })
         .on_menu_event(|app, event| match event.id().as_ref() {

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -22,9 +22,6 @@
                                 "decorations": true
                         }
                 ],
-                "trayIcon": {
-                        "iconPath": "icons/icon.png"
-                },
                 "security": {
                         "csp": "default-src 'self'; img-src 'self' http: https: data: blob:; media-src 'self' blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' http: https: ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self';",
                         "dangerousDisableAssetCspModification": false

--- a/murmer_client/src-tauri/tauri.conf.json
+++ b/murmer_client/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
         "$schema": "https://schema.tauri.app/config/2",
         "productName": "Murmer",
-        "version": "2026.713.0",
+        "version": "2026.714.0",
         "identifier": "com.murmer.app",
         "build": {
                 "beforeDevCommand": "npm run dev",

--- a/murmer_client/src/lib/chat/constants.ts
+++ b/murmer_client/src/lib/chat/constants.ts
@@ -2,6 +2,10 @@ import type { ChannelNotificationPreference } from '../stores/channelNotificatio
 
 export const MODERATOR_ROLES = ['Admin', 'Mod', 'Owner'] as const;
 
+/* The channel every server is seeded with. The server places new connections
+   into it and refuses to delete it, so the client can rely on it existing. */
+export const DEFAULT_CHANNEL_NAME = 'general';
+
 export const MESSAGE_INPUT_MAX_HEIGHT = 360;
 export const MAX_TOPIC_LENGTH = 256;
 export const PIN_PREVIEW_LIMIT = 120;

--- a/murmer_client/src/lib/components/SettingsModal.svelte
+++ b/murmer_client/src/lib/components/SettingsModal.svelte
@@ -16,7 +16,7 @@
   } from '$lib/stores/settings';
   import { APP_VERSION } from '$lib/version';
   import { serverInfo } from '$lib/stores/serverInfo';
-  import { theme, accent, DEFAULT_ACCENT } from '$lib/stores/theme';
+  import { theme, accent, DEFAULT_ACCENT, accentToHex, hexToAccent, type Accent } from '$lib/stores/theme';
   import ThemeWheel from '$lib/components/ThemeWheel.svelte';
   import { loadKeyPair } from '$lib/keypair';
   import { onMount, onDestroy } from 'svelte';
@@ -80,6 +80,50 @@
     { name: 'Ember', hue: 22, saturation: 80 },
     { name: 'Moss', hue: 150, saturation: 55 }
   ];
+
+  // The hex field mirrors the wheel. Edits only take effect on Enter or on
+  // blur, so a half-typed code never repaints the whole app.
+  let hexInput = accentToHex(DEFAULT_ACCENT);
+  let hexInvalid = false;
+  $: syncHexField($accent);
+
+  function syncHexField(value: Accent | null) {
+    hexInput = accentToHex(value ?? DEFAULT_ACCENT);
+    hexInvalid = false;
+  }
+
+  function commitHex() {
+    const parsed = hexToAccent(hexInput);
+    if (!parsed) {
+      hexInvalid = true;
+      return;
+    }
+    const current = $accent ?? DEFAULT_ACCENT;
+    if (parsed.hue === current.hue && parsed.saturation === current.saturation) {
+      // Unchanged: leaving the field must not pin the default palette to a
+      // wheel position, which would enable "Reset to default" out of nowhere.
+      hexInvalid = false;
+      return;
+    }
+    accent.set(parsed);
+    // Re-render from the stored position: the wheel drops the hex's
+    // lightness, so the field must show the color that was actually applied.
+    syncHexField(parsed);
+  }
+
+  /**
+   * The overlay closes the modal on Enter/Space, so keys typed here must not
+   * bubble that far — committing a color would otherwise dismiss settings.
+   * Escape still passes through to close the modal.
+   */
+  function handleHexKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') return;
+    event.stopPropagation();
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitHex();
+    }
+  }
 
   onMount(async () => {
     try {
@@ -299,6 +343,23 @@
                     ></button>
                   {/each}
                 </div>
+                <label class="field hex-field">
+                  <span>Hex code</span>
+                  <input
+                    class="hex-input"
+                    class:invalid={hexInvalid}
+                    type="text"
+                    maxlength="7"
+                    spellcheck="false"
+                    autocomplete="off"
+                    placeholder="#27c0e8"
+                    aria-invalid={hexInvalid}
+                    bind:value={hexInput}
+                    on:input={() => (hexInvalid = false)}
+                    on:blur={commitHex}
+                    on:keydown={handleHexKeydown}
+                  />
+                </label>
                 <button class="btn reset-accent" on:click={() => accent.reset()} disabled={$accent === null}>
                   Reset to default
                 </button>
@@ -306,6 +367,7 @@
             </div>
             <div class="setting-description">
               Drag the dot to recolor the whole app — the angle picks the color, the distance from the center picks how strong it is.
+              You can also type a hex code; its brightness is set by the theme, so only the color and its strength are taken from it.
             </div>
           </div>
         </div>
@@ -822,6 +884,21 @@
     box-shadow:
       0 0 0 2px var(--color-surface-elevated),
       0 0 0 4px var(--color-primary);
+  }
+
+  .hex-field {
+    gap: var(--space-1);
+  }
+
+  .hex-input {
+    width: 7rem;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+  }
+
+  .hex-input.invalid {
+    border-color: var(--color-warning);
+    box-shadow: 0 0 0 1px var(--color-warning);
   }
 
   .reset-accent {

--- a/murmer_client/src/lib/stores/theme.ts
+++ b/murmer_client/src/lib/stores/theme.ts
@@ -98,6 +98,60 @@ const LIGHT_SHAPE: PaletteShape = {
 
 const THEMED_TOKENS = Object.keys(DARK_SHAPE);
 
+/* The wheel only carries hue and saturation, so an accent is rendered as a
+   hex code at a fixed 50% lightness — the same level the preset swatches
+   use. A hex typed by the user is read back the same way: its hue and
+   saturation are kept, its lightness is dropped, because the palette above
+   supplies the lightness for every token. */
+const HEX_LIGHTNESS = 50;
+
+/** Renders a wheel position as `#rrggbb`. */
+export function accentToHex({ hue, saturation }: Accent): string {
+  const s = saturation / 100;
+  const l = HEX_LIGHTNESS / 100;
+  const chroma = (1 - Math.abs(2 * l - 1)) * s;
+  const channel = (n: number) => {
+    const k = (n + hue / 30) % 12;
+    const value = l - (chroma / 2) * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+    return Math.round(value * 255)
+      .toString(16)
+      .padStart(2, '0');
+  };
+  return `#${channel(0)}${channel(8)}${channel(4)}`;
+}
+
+/**
+ * Parses `#rgb`/`#rrggbb` (with or without the hash) into a wheel position.
+ * Returns null for anything else so callers can reject invalid input
+ * instead of applying a garbage palette.
+ */
+export function hexToAccent(input: string): Accent | null {
+  const raw = input.trim().replace(/^#/, '');
+  const expanded =
+    raw.length === 3
+      ? raw
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : raw;
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) return null;
+  const r = parseInt(expanded.slice(0, 2), 16) / 255;
+  const g = parseInt(expanded.slice(2, 4), 16) / 255;
+  const b = parseInt(expanded.slice(4, 6), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const l = (max + min) / 2;
+  if (delta === 0) return { hue: 0, saturation: 0 };
+  const saturation = delta / (1 - Math.abs(2 * l - 1));
+  let hue: number;
+  if (max === r) hue = ((g - b) / delta) % 6;
+  else if (max === g) hue = (b - r) / delta + 2;
+  else hue = (r - g) / delta + 4;
+  hue = (hue * 60 + 360) % 360;
+  return { hue: Math.round(hue), saturation: Math.round(Math.min(1, saturation) * 100) };
+}
+
 function applyAccent(mode: Theme, value: Accent | null) {
   if (typeof document === 'undefined') return;
   const style = document.documentElement.style;

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -34,7 +34,7 @@
   import { channels } from '$lib/stores/channels';
   import { voiceChannels } from '$lib/stores/voiceChannels';
   import { categories } from '$lib/stores/categories';
-  import type { CategoryInfo } from '$lib/types';
+  import type { CategoryInfo, ChannelInfo } from '$lib/types';
   import { leftSidebarWidth, rightSidebarWidth } from '$lib/stores/layout';
   import { channelTopics } from '$lib/stores/channelTopics';
   import { statuses, STATUS_LABELS, USER_STATUS_VALUES } from '$lib/stores/status';
@@ -75,7 +75,8 @@
     MIN_EPHEMERAL_SECONDS,
     MAX_EPHEMERAL_SECONDS,
     VOICE_QUALITY_PRESETS,
-    DEFAULT_VOICE_PRESET
+    DEFAULT_VOICE_PRESET,
+    DEFAULT_CHANNEL_NAME
   } from '$lib/chat/constants';
 
   let serverStrength = 0;
@@ -286,8 +287,16 @@
   });
   $: pinnedEntries = $pinned[currentChatChannelId] ?? [];
 
+  /* The server drops every connection into "general" and sends its history with
+     the presence response, so the initial pick has to be "general" too — the
+     channel list arrives sorted by name, which puts anything sorting ahead of
+     it at index 0. The fallback only covers servers seeded without "general". */
+  function defaultChannel(list: ChannelInfo[]): ChannelInfo {
+    return list.find((c) => c.name === DEFAULT_CHANNEL_NAME) ?? list[0];
+  }
+
   $: if ($channels.length && !$channels.some((c) => c.id === currentChatChannelId)) {
-    currentChatChannelId = $channels[0].id;
+    currentChatChannelId = defaultChannel($channels).id;
     unreadMarkerAfterId = unread.getLastRead(currentChatChannelId);
     unread.setActive(currentChatChannelId);
     loadingHistory = false;

--- a/murmer_server/Cargo.lock
+++ b/murmer_server/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "murmer_server"
-version = "2026.713.0"
+version = "2026.714.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/murmer_server/Cargo.toml
+++ b/murmer_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmer_server"
-version = "2026.713.0"
+version = "2026.714.0"
 edition = "2021"
 resolver = "2"
 


### PR DESCRIPTION
## What

The Appearance tab only offered the color wheel and the six preset swatches, so a color you already had as a hex code could not be dialed in exactly. This adds a **Hex code** field next to the wheel.

- The field mirrors the active accent and follows along when you drag the wheel or click a preset.
- Edits apply on **Enter** or on **blur** — typing alone does nothing, so a half-typed code like `#f` never repaints the whole app.
- Accepts `#rrggbb`, `#rgb` shorthand, and input without the leading `#`. Invalid input is marked (warning border + `aria-invalid`) and leaves the palette untouched; the mark clears on the next keystroke.

## Why the field can show a different code than you typed

The accent model is hue + saturation only — `theme.ts` supplies the lightness per token from its hand-tuned palette shape. A typed hex therefore contributes its hue and saturation, and the field re-renders at the theme's lightness (50%, the same level the preset swatches use). Typing `#c0392b` shows `#d03f2f` back: same color and strength, normalized brightness. The description text under the wheel says so. Carrying the lightness through would mean extending the accent model and overriding the per-token lightness ramp, which seemed like the wrong trade for this.

## Bug found and fixed along the way

Enter in the field closed the entire settings modal: the overlay has an a11y handler that calls `close()` on Enter/Space, and the keydown bubbled up to it from the input. A space would have done the same. Keys from the hex field now stop before the overlay; Escape still closes the modal as before.

## Testing

Driven in the running client (`npm run tauri dev` webview via the dev server), not just typechecked:

- Enter and blur both commit and recolor the palette, wheel dot, and `localStorage`; Enter keeps the modal open, Space does not close it, Escape still does.
- Invalid input rejected without touching the palette; error clears on next input; `#rgb` shorthand works.
- Clicking into the field and leaving it without editing no longer pins the default palette to a wheel position (previously would have enabled "Reset to default" out of nowhere).
- "Reset to default" returns to the built-in palette and resets the field.
- Conversion is a round-trip fixed point across all 36k wheel positions; drift only appears below saturation 20, where 8-bit hex cannot resolve hue any finer — visually indistinguishable.
- `npm run check`: 380 files, 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
