### PR TITLE
Group role assignments into a "Set Role" submenu

### DIFF
--- a/murmer_client/src/lib/components/ContextMenu.svelte
+++ b/murmer_client/src/lib/components/ContextMenu.svelte
@@ -1,23 +1,90 @@
 <!--
   Modern floating context menu with smooth animations and micro-interactions.
   Accepts a list of menu items and exposes coordinates for positioning relative
-  to the user's cursor. Features fade-in/scale animation and keyboard navigation.
+  to the user's cursor. Items carrying `children` open a flyout submenu on
+  hover or click. Features fade-in/scale animation and keyboard navigation.
 -->
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
-  import { fly, scale } from 'svelte/transition';
+  import { onMount, onDestroy, tick } from 'svelte';
+  import { fly } from 'svelte/transition';
   import { cubicOut } from 'svelte/easing';
-  
-  export let items: { label: string; action: () => void; danger?: boolean; icon?: string }[] = [];
+  import type { ContextMenuItem } from '$lib/types';
+
+  export let items: ContextMenuItem[] = [];
   export let x = 0;
   export let y = 0;
   export let open = false;
 
   let menuElement: HTMLUListElement;
-  let mounted = false;
+  let submenuElement: HTMLUListElement | undefined;
+
+  /** Index of the item whose submenu is currently shown, if any. */
+  let openSubmenu: number | null = null;
+  /** Submenu opens to the left when it would leave the viewport on the right. */
+  let submenuFlip = false;
+  /** Pixels the submenu is pulled up by to stay inside the viewport. */
+  let submenuShift = 0;
+  /** Grace period so the cursor may cross the gap between the menu and its
+   *  submenu without the submenu disappearing underneath it. */
+  let submenuCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** A menu with submenus must not clip them, so it cannot be a scroll box.
+   *  Keep such menus short enough to fit on screen. */
+  $: hasSubmenu = items.some((item) => item.children?.length);
+
+  function cancelSubmenuClose() {
+    if (submenuCloseTimer !== null) {
+      clearTimeout(submenuCloseTimer);
+      submenuCloseTimer = null;
+    }
+  }
+
+  function closeSubmenu() {
+    cancelSubmenuClose();
+    openSubmenu = null;
+  }
+
+  function scheduleSubmenuClose() {
+    cancelSubmenuClose();
+    submenuCloseTimer = setTimeout(() => {
+      openSubmenu = null;
+      submenuCloseTimer = null;
+    }, 150);
+  }
+
+  /** Opens the submenu of `index`, then nudges it back inside the viewport.
+   *  It is positioned against its parent item rather than the viewport so the
+   *  menu's own open transition cannot displace it. */
+  async function showSubmenu(index: number) {
+    cancelSubmenuClose();
+    if (openSubmenu === index) return;
+    submenuFlip = false;
+    submenuShift = 0;
+    openSubmenu = index;
+    await tick();
+    if (!submenuElement || openSubmenu !== index) return;
+    let rect = submenuElement.getBoundingClientRect();
+    if (rect.right > window.innerWidth - 8) {
+      submenuFlip = true;
+      await tick();
+      if (!submenuElement || openSubmenu !== index) return;
+      rect = submenuElement.getBoundingClientRect();
+    }
+    const overflowBottom = rect.bottom - (window.innerHeight - 8);
+    if (overflowBottom > 0) {
+      submenuShift = Math.min(overflowBottom, Math.max(0, rect.top - 8));
+    }
+  }
 
   function close() {
     open = false;
+    closeSubmenu();
+  }
+
+  function activate(item: ContextMenuItem) {
+    if (item.children) return;
+    item.action?.();
+    close();
   }
 
   function handleClickOutside(event: MouseEvent) {
@@ -28,66 +95,123 @@
 
   function handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
-      close();
+      if (openSubmenu !== null) closeSubmenu();
+      else close();
     }
   }
 
   onMount(() => {
-    mounted = true;
     document.addEventListener('click', handleClickOutside);
     document.addEventListener('contextmenu', handleClickOutside);
     document.addEventListener('keydown', handleKeydown);
   });
-  
+
   onDestroy(() => {
+    cancelSubmenuClose();
     document.removeEventListener('click', handleClickOutside);
     document.removeEventListener('contextmenu', handleClickOutside);
     document.removeEventListener('keydown', handleKeydown);
   });
 
-  // Ensure menu doesn't go off screen
-  $: adjustedX = x;
-  $: adjustedY = y;
-  $: if (menuElement && mounted) {
+  // A freshly opened menu never carries over the previous target's submenu.
+  $: if (!open) closeSubmenu();
+
+  /** Places the menu at the cursor, then pulls it back inside the viewport.
+   *  The menu has to be on screen before it can be measured, so this runs
+   *  once the requested position has been rendered. */
+  async function placeMenu(cursorX: number, cursorY: number) {
+    adjustedX = cursorX;
+    adjustedY = cursorY;
+    await tick();
+    if (!menuElement) return;
     const rect = menuElement.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    
-    if (rect.right > viewportWidth) {
-      adjustedX = x - (rect.right - viewportWidth) - 8;
+    if (rect.right > window.innerWidth - 8) {
+      adjustedX = Math.max(8, window.innerWidth - rect.width - 8);
     }
-    if (rect.bottom > viewportHeight) {
-      adjustedY = y - (rect.bottom - viewportHeight) - 8;
+    if (rect.bottom > window.innerHeight - 8) {
+      adjustedY = Math.max(8, window.innerHeight - rect.height - 8);
     }
   }
+
+  let adjustedX = 0;
+  let adjustedY = 0;
+  $: if (open) placeMenu(x, y);
 </script>
 
 {#if open}
   <ul
     bind:this={menuElement}
     class="menu"
+    class:menu-unclipped={hasSubmenu}
     style="top:{adjustedY}px;left:{adjustedX}px"
     transition:fly={{ y: -8, duration: 180, easing: cubicOut }}
     role="menu"
   >
     {#each items as item, index (index)}
-      <li role="none">
+      <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+      <li
+        role="none"
+        class:has-submenu={!!item.children}
+        on:mouseenter={() => (item.children ? showSubmenu(index) : closeSubmenu())}
+        on:mouseleave={() => item.children && scheduleSubmenuClose()}
+      >
         <button
           type="button"
           class="entry"
           class:entry-danger={item.danger}
-          on:click={() => {
-            item.action();
-            close();
-          }}
+          class:entry-active={openSubmenu === index}
+          on:click={() => (item.children ? showSubmenu(index) : activate(item))}
           role="menuitem"
+          aria-haspopup={item.children ? 'menu' : undefined}
+          aria-expanded={item.children ? openSubmenu === index : undefined}
           tabindex="0"
         >
           {#if item.icon}
             <span class="entry-icon" aria-hidden="true">{item.icon}</span>
           {/if}
           <span class="entry-label">{item.label}</span>
+          {#if item.children}
+            <svg
+              class="entry-chevron"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M9 6l6 6-6 6" />
+            </svg>
+          {/if}
         </button>
+        {#if item.children && openSubmenu === index}
+          <ul
+            bind:this={submenuElement}
+            class="menu submenu"
+            class:submenu-flip={submenuFlip}
+            style="top:calc({-submenuShift}px - var(--space-1))"
+            role="menu"
+          >
+            {#each item.children as child, childIndex (childIndex)}
+              <li role="none">
+                <button
+                  type="button"
+                  class="entry"
+                  class:entry-danger={child.danger}
+                  on:click={() => activate(child)}
+                  role="menuitem"
+                  tabindex="0"
+                >
+                  {#if child.icon}
+                    <span class="entry-icon" aria-hidden="true">{child.icon}</span>
+                  {/if}
+                  <span class="entry-label">{child.label}</span>
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
       </li>
     {/each}
   </ul>
@@ -109,6 +233,28 @@
     overflow-y: auto;
   }
 
+  .menu-unclipped {
+    max-height: none;
+    overflow: visible;
+  }
+
+  .has-submenu {
+    position: relative;
+  }
+
+  /* Anchored to its parent item, so it follows the menu's open transition
+     instead of being displaced by it. The gap is bridged by the close delay. */
+  .submenu {
+    position: absolute;
+    left: calc(100% + var(--space-1));
+    min-width: 160px;
+  }
+
+  .submenu-flip {
+    left: auto;
+    right: calc(100% + var(--space-1));
+  }
+
   .entry {
     padding: var(--space-2) var(--space-3);
     cursor: pointer;
@@ -127,7 +273,8 @@
   }
 
   .entry:hover,
-  .entry:focus-visible {
+  .entry:focus-visible,
+  .entry-active {
     background: var(--color-surface-raised);
     color: var(--color-on-surface);
   }
@@ -149,6 +296,13 @@
 
   .entry-label {
     flex: 1;
+  }
+
+  .entry-chevron {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+    color: var(--color-muted);
   }
 
   .entry:focus-visible {

--- a/murmer_client/src/lib/types.ts
+++ b/murmer_client/src/lib/types.ts
@@ -96,3 +96,13 @@ export interface ScreenShareActive {
   userId: string;
   channelId: number;
 }
+
+/** Entry of a right-click menu. Items with `children` open a submenu instead
+ *  of running an action. */
+export interface ContextMenuItem {
+  label: string;
+  action?: () => void;
+  danger?: boolean;
+  icon?: string;
+  children?: ContextMenuItem[];
+}

--- a/murmer_client/src/routes/chat/+page.svelte
+++ b/murmer_client/src/routes/chat/+page.svelte
@@ -34,7 +34,7 @@
   import { channels } from '$lib/stores/channels';
   import { voiceChannels } from '$lib/stores/voiceChannels';
   import { categories } from '$lib/stores/categories';
-  import type { CategoryInfo, ChannelInfo } from '$lib/types';
+  import type { CategoryInfo, ChannelInfo, ContextMenuItem } from '$lib/types';
   import { leftSidebarWidth, rightSidebarWidth } from '$lib/stores/layout';
   import { channelTopics } from '$lib/stores/channelTopics';
   import { statuses, STATUS_LABELS, USER_STATUS_VALUES } from '$lib/stores/status';
@@ -1137,15 +1137,17 @@
     if (!userRoleMenuTarget) return [];
     const target = userRoleMenuTarget;
     const currentRole = $roles[target]?.role;
-    const items: { label: string; action: () => void; danger?: boolean; icon?: string }[] = [];
+    const items: ContextMenuItem[] = [];
     items.push({ label: 'Send Message', action: () => openDm(target) });
     if (currentUserIsOwner) {
-      for (const role of ASSIGNABLE_ROLES) {
-        if (currentRole?.toLowerCase() === role.toLowerCase()) continue;
-        items.push({ label: `Set as ${role}`, action: () => assignRole(target, role) });
-      }
+      const roleItems: ContextMenuItem[] = ASSIGNABLE_ROLES.filter(
+        (role) => currentRole?.toLowerCase() !== role.toLowerCase()
+      ).map((role) => ({ label: role, action: () => assignRole(target, role) }));
       if (currentRole) {
-        items.push({ label: 'Remove Role', action: () => removeRole(target), danger: true });
+        roleItems.push({ label: 'Remove Role', action: () => removeRole(target), danger: true });
+      }
+      if (roleItems.length) {
+        items.push({ label: 'Set Role', children: roleItems });
       }
     }
     if (canModerate(target)) {


### PR DESCRIPTION
## What changed

The user context menu (right-click a user in the user list) listed `Set as Owner`, `Set as Admin`, `Set as Mod` and `Remove Role` as four separate top-level entries. They are now grouped into a single **Set Role ▸** entry that opens a flyout submenu.

Behaviour is otherwise unchanged: the group is still owner-only, the target's current role is still filtered out of the list, and the moderation actions (mute/kick/ban) are untouched.

- `types.ts` — new shared `ContextMenuItem` type; an item carrying `children` is a submenu parent.
- `ContextMenu.svelte` — submenu support: opens on hover or click, closes when a sibling item is hovered or after a 150 ms grace delay so the cursor can cross into the flyout, and Escape closes the submenu before the menu.
- `chat/+page.svelte` — builds the role entries as `children` of one `Set Role` item.

## Notes for reviewers

**Two positioning bugs came up while building this.**

1. The submenu was initially `position: fixed` and landed ~60px adrift, because Svelte's `fly` transition puts a transform on the menu, which makes it the containing block for fixed descendants. It is now positioned absolutely against its parent item, which is correct regardless of transition state.

2. Pre-existing, not introduced here: the menu's own viewport clamp measured a stale rect and applied the *previous* position's correction, so reopening near an edge threw it off-screen (measured at `left: 1250` in a 1280px viewport, and once at `top: -116`). Correct submenu placement depends on the menu being placed correctly, so this is fixed with the same measure-after-render approach.

**One deliberate trade-off:** a menu containing a submenu can no longer scroll (`max-height` is dropped), since a scroll box would clip the flyout. That is fine for the user menu at ~9 items, and the long channel menu has no submenus — but it is a constraint to remember if a submenu is ever added to a long menu.

## Testing

- `npm run check` passes clean (380 files, 0 errors, 0 warnings).
- Verified in a browser by mounting `ContextMenu` in a temporary route (the chat page needs a live server and an owner login), driving it through the DOM and measuring geometry at five cursor positions: menu and submenu both stay inside the viewport, the submenu flips left near the right edge, shifts up near the bottom, and sits flush against the parent menu with no gap to fall through. Click-to-activate, hover-away close, sibling-hover close and Escape were each exercised. The temporary route was removed.

This PR also carries four commits that were already on `dev` but not yet merged into `main` (release v2026.714.0, tray icon fix, #general default, TODO notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)